### PR TITLE
Resolve npm build failure

### DIFF
--- a/src/HarmoniHSE360.Web/ClientApp/package-lock.json
+++ b/src/HarmoniHSE360.Web/ClientApp/package-lock.json
@@ -29,6 +29,7 @@
         "yup": "^1.3.3"
       },
       "devDependencies": {
+        "@types/node": "^20.11.19",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^8.33.1",
@@ -3280,18 +3281,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4134,7 +4145,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -7963,6 +7974,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/src/HarmoniHSE360.Web/ClientApp/package.json
+++ b/src/HarmoniHSE360.Web/ClientApp/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
+    "@types/node": "^20.11.19",
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/HarmoniHSE360.Web/ClientApp/src/components/dashboard/DonutChart.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/components/dashboard/DonutChart.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 interface DonutChartData {
   label: string;
   value: number;
-  color: string;
+  color?: string;
 }
 
 interface DonutChartProps {

--- a/src/HarmoniHSE360.Web/ClientApp/src/components/dashboard/StatsCard.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/components/dashboard/StatsCard.tsx
@@ -7,12 +7,17 @@ interface StatsCardProps {
   value: string | number;
   subtitle?: string;
   icon?: any;
-  color?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info';
+  color?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'dark';
   trend?: {
     value: number;
     isPositive: boolean;
     label: string;
   };
+  /**
+   * Temporary backwards compatibility property.
+   * @deprecated use `trend` instead
+   */
+  change?: number;
   isLoading?: boolean;
   onClick?: () => void;
   className?: string;
@@ -25,12 +30,18 @@ const StatsCard: React.FC<StatsCardProps> = ({
   icon,
   color = 'primary',
   trend,
+  change,
   isLoading = false,
   onClick,
   className = ''
 }) => {
   const cardClass = `stats-card ${onClick ? 'clickable' : ''} ${className}`;
   const colorClass = `border-start border-start-4 border-${color}`;
+  const finalTrend = trend ?? (change !== undefined ? {
+    value: change,
+    isPositive: change >= 0,
+    label: ''
+  } : undefined);
 
   return (
     <CCard 
@@ -57,12 +68,12 @@ const StatsCard: React.FC<StatsCardProps> = ({
               </>
             )}
           </div>
-          {trend && !isLoading && (
+          {finalTrend && !isLoading && (
             <div className="text-medium-emphasis small mt-1">
-              <span className={`fw-semibold ${trend.isPositive ? 'text-success' : 'text-danger'}`}>
-                {trend.isPositive ? '↗' : '↘'} {Math.abs(trend.value)}%
+              <span className={`fw-semibold ${finalTrend.isPositive ? 'text-success' : 'text-danger'}`}>
+                {finalTrend.isPositive ? '↗' : '↘'} {Math.abs(finalTrend.value)}%
               </span>
-              <span className="ms-1">{trend.label}</span>
+              <span className="ms-1">{finalTrend.label}</span>
             </div>
           )}
         </div>

--- a/src/HarmoniHSE360.Web/ClientApp/src/features/incidents/incidentApi.ts
+++ b/src/HarmoniHSE360.Web/ClientApp/src/features/incidents/incidentApi.ts
@@ -420,8 +420,8 @@ export const incidentApi = createApi({
     }),
 
     // Get incident dashboard data
-    getIncidentDashboard: builder.query<IncidentDashboardDto, IncidentDashboardParams | void>({
-      query: (params = {}) => {
+    getIncidentDashboard: builder.query<IncidentDashboardDto, IncidentDashboardParams>({
+      query: (params: IncidentDashboardParams = {}) => {
         const searchParams = new URLSearchParams();
         
         if (params.fromDate) searchParams.append('fromDate', params.fromDate);
@@ -435,7 +435,7 @@ export const incidentApi = createApi({
           method: 'GET',
         };
       },
-      providesTags: ['IncidentDashboard', 'IncidentStatistics'],
+      providesTags: ['IncidentStatistics'],
     }),
 
     // Delete incident

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/HazardList.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/HazardList.tsx
@@ -45,10 +45,10 @@ const HazardList: React.FC = () => {
   const { data, isLoading, error } = useGetHazardsQuery(filters);
 
   const handleFilterChange = (field: keyof GetHazardsParams, value: string | number) => {
-    setFilters(prev => ({ 
-      ...prev, 
-      [field]: value,
-      pageNumber: field !== 'pageNumber' ? 1 : value // Reset to first page when changing filters
+    setFilters(prev => ({
+      ...prev,
+      [field]: field === 'pageNumber' ? Number(value) : value,
+      pageNumber: field !== 'pageNumber' ? 1 : Number(value)
     }));
   };
 

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/HazardMapping.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/HazardMapping.tsx
@@ -33,7 +33,6 @@ import {
   faExclamationTriangle,
   faEye,
   faRoute,
-  faLayersAlt,
   faCalendarAlt,
   faBuilding,
   faUser,
@@ -417,7 +416,7 @@ const HazardMapping: React.FC = () => {
                             <CBadge color={getRiskBadgeColor(hazard.currentRiskLevel || 'Not Assessed')}>
                               {hazard.currentRiskLevel || 'Not Assessed'}
                             </CBadge>
-                            <CBadge color="light" text="dark">
+                            <CBadge color="light" textColor="dark">
                               {hazard.category}
                             </CBadge>
                           </div>

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/MobileHazardReport.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/MobileHazardReport.tsx
@@ -102,7 +102,7 @@ const MobileHazardReport: React.FC = () => {
         // Try to get address from coordinates
         try {
           const response = await fetch(
-            `https://api.geocoding.com/v1/reverse?lat=${locationData.latitude}&lng=${locationData.longitude}&api_key=${process.env.REACT_APP_GEOCODING_API_KEY}`
+            `https://api.geocoding.com/v1/reverse?lat=${locationData.latitude}&lng=${locationData.longitude}&api_key=${import.meta.env.VITE_GEOCODING_API_KEY}`
           );
           
           if (response.ok) {
@@ -301,7 +301,7 @@ const MobileHazardReport: React.FC = () => {
               <FontAwesomeIcon icon={faExclamationTriangle} className="me-2" />
               Report Hazard
             </h5>
-            <CBadge color="light" text="dark">
+            <CBadge color="light" textColor="dark">
               Step {step} of {totalSteps}
             </CBadge>
           </div>

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/MyHazards.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/MyHazards.tsx
@@ -46,10 +46,10 @@ const MyHazards: React.FC = () => {
   const { data, isLoading, error } = useGetMyHazardsQuery(filters);
 
   const handleFilterChange = (field: keyof GetHazardsParams, value: string | number) => {
-    setFilters(prev => ({ 
-      ...prev, 
-      [field]: value,
-      pageNumber: field !== 'pageNumber' ? 1 : value // Reset to first page when changing filters
+    setFilters(prev => ({
+      ...prev,
+      [field]: field === 'pageNumber' ? Number(value) : value,
+      pageNumber: field !== 'pageNumber' ? 1 : Number(value)
     }));
   };
 

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/RiskAssessments.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/hazards/RiskAssessments.tsx
@@ -44,10 +44,10 @@ const RiskAssessments: React.FC = () => {
   const { data, isLoading, error } = useGetUnassessedHazardsQuery(filters);
 
   const handleFilterChange = (field: keyof GetHazardsParams, value: string | number) => {
-    setFilters(prev => ({ 
-      ...prev, 
-      [field]: value,
-      pageNumber: field !== 'pageNumber' ? 1 : value
+    setFilters(prev => ({
+      ...prev,
+      [field]: field === 'pageNumber' ? Number(value) : value,
+      pageNumber: field !== 'pageNumber' ? 1 : Number(value)
     }));
   };
 

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/incidents/IncidentDashboard.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/incidents/IncidentDashboard.tsx
@@ -19,18 +19,16 @@ import {
   CDropdownItem
 } from '@coreui/react';
 import CIcon from '@coreui/icons-react';
-import {
-  cilWarning,
-  cilShieldAlt,
-  cilTask,
-  cilClock,
-  cilTrendUp,
-  cilPeople,
-  cilLocationPin,
-  cilChartLine,
-  cilReload,
-  cilOptions
-} from '@coreui/icons';
+import { HubConnectionState } from '@microsoft/signalr';
+import { cilWarning } from '@coreui/icons/dist/esm/free/cil-warning';
+import { cilShieldAlt } from '@coreui/icons/dist/esm/free/cil-shield-alt';
+import { cilTask } from '@coreui/icons/dist/esm/free/cil-task';
+import { cilClock } from '@coreui/icons/dist/esm/free/cil-clock';
+import { cilPeople } from '@coreui/icons/dist/esm/free/cil-people';
+import { cilLocationPin } from '@coreui/icons/dist/esm/free/cil-location-pin';
+import { cilChartLine } from '@coreui/icons/dist/esm/free/cil-chart-line';
+import { cilReload } from '@coreui/icons/dist/esm/free/cil-reload';
+import { cilOptions } from '@coreui/icons/dist/esm/free/cil-options';
 
 import { useGetIncidentDashboardQuery } from '../../features/incidents/incidentApi';
 import { useSignalR } from '../../hooks/useSignalR';
@@ -80,7 +78,7 @@ const IncidentDashboard: React.FC = () => {
     }
   };
 
-  const { data: dashboardData, isLoading, error, refetch, dataUpdatedAt } = useGetIncidentDashboardQuery({
+  const { data: dashboardData, isLoading, error, refetch, fulfilledTimeStamp } = useGetIncidentDashboardQuery({
     ...getDateRange(),
     department: department || undefined,
     includeResolved: true
@@ -88,10 +86,10 @@ const IncidentDashboard: React.FC = () => {
 
   // Update last refresh time when data changes
   useEffect(() => {
-    if (dataUpdatedAt) {
-      setLastRefreshTime(new Date(dataUpdatedAt));
+    if (fulfilledTimeStamp) {
+      setLastRefreshTime(new Date(fulfilledTimeStamp));
     }
-  }, [dataUpdatedAt]);
+  }, [fulfilledTimeStamp]);
 
   // Handle auto-refresh
   useEffect(() => {
@@ -234,7 +232,7 @@ const IncidentDashboard: React.FC = () => {
                     <span className="d-none d-sm-inline">{isLoading ? 'Refreshing...' : 'Refresh'}</span>
                     <span className="d-sm-none">{isLoading ? '...' : 'Refresh'}</span>
                   </CButton>
-                  <CDropdown variant="btn-group" size="sm">
+                  <CDropdown variant="btn-group">
                     <CDropdownToggle color="secondary" variant="outline">
                       <CIcon icon={cilOptions} className="me-1 d-none d-sm-inline" />
                       <span className="d-none d-md-inline">Auto-refresh: </span>
@@ -258,7 +256,7 @@ const IncidentDashboard: React.FC = () => {
                 </CButtonToolbar>
                 <div className="text-medium-emphasis small text-end flex-shrink-0">
                   <div className="text-truncate-mobile">Last: {formatDistanceToNow(lastRefreshTime, { addSuffix: true })}</div>
-                  {connectionState === 1 && (
+                  {connectionState === HubConnectionState.Connected && (
                     <div className="text-success d-none d-sm-block">
                       <small>● Live updates</small>
                     </div>

--- a/src/HarmoniHSE360.Web/ClientApp/src/pages/ppe/PPEDashboard.tsx
+++ b/src/HarmoniHSE360.Web/ClientApp/src/pages/ppe/PPEDashboard.tsx
@@ -26,20 +26,18 @@ import {
   CDropdownItem
 } from '@coreui/react';
 import CIcon from '@coreui/icons-react';
-import {
-  cilShieldAlt,
-  cilWarning,
-  cilTask,
-  cilClock,
-  cilTrendUp,
-  cilPeople,
-  cilLocationPin,
-  cilChartLine,
-  cilReload,
-  cilOptions,
-  cilPlus
-} from '@coreui/icons';
+import { cilShieldAlt } from '@coreui/icons/dist/esm/free/cil-shield-alt';
+import { cilWarning } from '@coreui/icons/dist/esm/free/cil-warning';
+import { cilTask } from '@coreui/icons/dist/esm/free/cil-task';
+import { cilClock } from '@coreui/icons/dist/esm/free/cil-clock';
+import { cilPeople } from '@coreui/icons/dist/esm/free/cil-people';
+import { cilLocationPin } from '@coreui/icons/dist/esm/free/cil-location-pin';
+import { cilChartLine } from '@coreui/icons/dist/esm/free/cil-chart-line';
+import { cilReload } from '@coreui/icons/dist/esm/free/cil-reload';
+import { cilOptions } from '@coreui/icons/dist/esm/free/cil-options';
+import { cilPlus } from '@coreui/icons/dist/esm/free/cil-plus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { HubConnectionState } from '@microsoft/signalr';
 import { ACTION_ICONS, CONTEXT_ICONS } from '../../utils/iconMappings';
 import {
   faShieldAlt,
@@ -98,7 +96,7 @@ const PPEDashboard: React.FC = () => {
     }
   };
 
-  const { data: dashboard, error, isLoading, refetch, dataUpdatedAt } = useGetPPEDashboardQuery({
+  const { data: dashboard, error, isLoading, refetch, fulfilledTimeStamp } = useGetPPEDashboardQuery({
     ...getDateRange(),
     category: category || undefined
   }, {
@@ -110,10 +108,10 @@ const PPEDashboard: React.FC = () => {
 
   // Update last refresh time when data changes
   useEffect(() => {
-    if (dataUpdatedAt) {
-      setLastRefreshTime(new Date(dataUpdatedAt));
+    if (fulfilledTimeStamp) {
+      setLastRefreshTime(new Date(fulfilledTimeStamp));
     }
-  }, [dataUpdatedAt]);
+  }, [fulfilledTimeStamp]);
 
   // Handle auto-refresh
   useEffect(() => {
@@ -246,7 +244,7 @@ const PPEDashboard: React.FC = () => {
                     <span className="d-none d-sm-inline">{isLoading ? 'Refreshing...' : 'Refresh'}</span>
                     <span className="d-sm-none">{isLoading ? '...' : 'Refresh'}</span>
                   </CButton>
-                  <CDropdown variant="btn-group" size="sm">
+                  <CDropdown variant="btn-group">
                     <CDropdownToggle color="secondary" variant="outline">
                       <CIcon icon={cilOptions} className="me-1 d-none d-sm-inline" />
                       <span className="d-none d-md-inline">Auto-refresh: </span>
@@ -270,7 +268,7 @@ const PPEDashboard: React.FC = () => {
                 </CButtonToolbar>
                 <div className="text-medium-emphasis small text-end flex-shrink-0">
                   <div className="text-truncate-mobile">Last: {formatDistanceToNow(lastRefreshTime, { addSuffix: true })}</div>
-                  {connectionState === 1 && (
+                  {connectionState === HubConnectionState.Connected && (
                     <div className="text-success d-none d-sm-block">
                       <small>● Live updates</small>
                     </div>

--- a/src/HarmoniHSE360.Web/ClientApp/src/services/signalrService.ts
+++ b/src/HarmoniHSE360.Web/ClientApp/src/services/signalrService.ts
@@ -165,7 +165,7 @@ class SignalRService {
       console.log('SignalR: Dashboard update received');
       // Invalidate dashboard cache to trigger refetch
       store.dispatch(
-        incidentApi.util.invalidateTags(['IncidentDashboard', 'IncidentStatistics'])
+        incidentApi.util.invalidateTags(['IncidentStatistics'])
       );
       // Also invalidate PPE dashboard
       try {

--- a/src/HarmoniHSE360.Web/ClientApp/src/types/hazard.ts
+++ b/src/HarmoniHSE360.Web/ClientApp/src/types/hazard.ts
@@ -337,6 +337,7 @@ export interface ComplianceMetrics {
 }
 
 export interface RecentActivityDto {
+  id: number;
   activityType: string;
   title: string;
   description: string;
@@ -347,6 +348,7 @@ export interface RecentActivityDto {
 }
 
 export interface HazardAlertDto {
+  id: number;
   alertType: string;
   title: string;
   message: string;

--- a/src/HarmoniHSE360.Web/ClientApp/src/vite-env.d.ts
+++ b/src/HarmoniHSE360.Web/ClientApp/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- align `getIncidentDashboard` query type definition
- add optional change value support to `StatsCard`
- relax `DonutChart` color field
- expose id fields for hazard data types
- include `@types/node` for better type checks
- fix TypeScript errors: use HubConnectionState, remove invalid icons, use import.meta.env, correct filter setters, allow dark stats card
- add vite-env declaration for environment variables

## Testing
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b95c3ce608327b4fe49b06ad8c0c1