### PR TITLE
Fix Fly.io restart configuration

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -55,5 +55,5 @@ primary_region = "sjc"
   memory_mb = 1024
 
 # Restart policy for production stability
-[restart]
+[[restart]]
   policy = "always"


### PR DESCRIPTION
## Summary
- correct the restart configuration table in `fly.toml` to match Fly.io schema

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0846123483278bc2124ab49f5539