### PR TITLE
Fix docker build missing charts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,6 @@
 **/*.jfm
 **/azds.yaml
 **/bin
-**/charts
 **/docker-compose*
 **/Dockerfile*
 **/node_modules


### PR DESCRIPTION
## Summary
- fix `.dockerignore` to include inspection chart components during Docker builds

## Testing
- `npm run build` in `src/Harmoni360.Web/ClientApp`


------
https://chatgpt.com/codex/tasks/task_e_684c0d7a44e8832796cde4253bbe8a91