### PR TITLE
Skip client build inside dotnet publish

### DIFF
--- a/Dockerfile.flyio
+++ b/Dockerfile.flyio
@@ -22,7 +22,7 @@ RUN npm run build
 
 # Build .NET app
 WORKDIR /src/Harmoni360.Web
-RUN dotnet publish "Harmoni360.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "Harmoni360.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:SkipClientBuild=true
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final

--- a/src/Harmoni360.Web/Harmoni360.Web.csproj
+++ b/src/Harmoni360.Web/Harmoni360.Web.csproj
@@ -8,6 +8,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <SpaProxyServerUrl>http://localhost:5173</SpaProxyServerUrl>
     <UserSecretsId>27956cca-ed46-4f3f-b393-cd88f0c18d1a</UserSecretsId>
+    <SkipClientBuild>false</SkipClientBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,8 +49,8 @@
   </Target>
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" Condition="'$(SkipClientBuild)' != 'true'" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" Condition="'$(SkipClientBuild)' != 'true'" />
     <ItemGroup>
       <DistFiles Include="$(SpaRoot)dist\**" />
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">


### PR DESCRIPTION
## Summary
- allow skipping of npm build during publish with `SkipClientBuild` property
- set `SkipClientBuild=true` in Dockerfile to avoid running `npm run build` twice

## Testing
- `npm run build` (after `npm ci`)

------
https://chatgpt.com/codex/tasks/task_e_684c13f050408327b235d50fd2cc8e05