### PR TITLE
Add Fly.io domain instructions

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,124 @@
+# Harmoni360 Production Environment Configuration
+# Copy this file to .env.prod and customize the values for your deployment
+
+# =============================================================================
+# DEPLOYMENT CONFIGURATION
+# =============================================================================
+COMPOSE_PROJECT_NAME=harmoni360-prod
+BUILD_VERSION=latest
+
+# =============================================================================
+# PATHS CONFIGURATION
+# =============================================================================
+# Base data directory (ensure this exists and has proper permissions)
+DATA_PATH=/opt/harmoni360/data
+LOG_PATH=/opt/harmoni360/logs
+BACKUP_PATH=/opt/harmoni360/backups
+
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
+POSTGRES_DB=Harmoni360_Prod
+POSTGRES_USER=harmoni360
+# REQUIRED: Set a strong password for PostgreSQL
+POSTGRES_PASSWORD=1TC6OLSVEKQu3xgWmccmZ5T10hhmLWM4K08S/FWXf9Y=
+
+# PostgreSQL Performance Tuning (adjust based on your server specs)
+POSTGRES_SHARED_BUFFERS=2GB
+POSTGRES_EFFECTIVE_CACHE_SIZE=6GB
+POSTGRES_WORK_MEM=64MB
+POSTGRES_MAINTENANCE_WORK_MEM=512MB
+POSTGRES_MAX_CONNECTIONS=300
+
+# =============================================================================
+# REDIS CONFIGURATION
+# =============================================================================
+# REQUIRED: Set a strong password for Redis
+REDIS_PASSWORD=GGtAv06cM58tAf5UacwN9W0IM1EM6ckb5W9T4loEG4I=
+
+# =============================================================================
+# JWT CONFIGURATION
+# =============================================================================
+# REQUIRED: Generate a secure JWT key (minimum 32 characters)
+# Use: openssl rand -base64 32
+JWT_KEY=T4EP8UzMe0CZJXf87AmZvhpZUxbEvd1h/sLEmO0fA74=
+JWT_ISSUER=Harmoni360
+JWT_AUDIENCE=Harmoni360Users
+JWT_EXPIRATION_MINUTES=60
+JWT_REFRESH_EXPIRATION_DAYS=7
+
+# =============================================================================
+# APPLICATION CONFIGURATION
+# =============================================================================
+# Maximum file upload size in bytes (100MB default)
+MAX_FILE_SIZE=104857600
+
+# =============================================================================
+# LOGGING CONFIGURATION
+# =============================================================================
+# REQUIRED: Generate Seq admin password hash
+# Use: echo 'your-password' | docker run --rm -i datalust/seq config hash
+SEQ_ADMIN_PASSWORD_HASH=$SHA256$V1$10000$placeholder_hash
+
+# =============================================================================
+# MONITORING CONFIGURATION
+# =============================================================================
+# REQUIRED: Set Grafana admin password
+GRAFANA_ADMIN_PASSWORD=ulHkvVVA5VlS6WB+l5KEAg==
+
+# =============================================================================
+# SSL/TLS CONFIGURATION
+# =============================================================================
+# Domain name for SSL certificate
+DOMAIN_NAME=harmoni-360.fly.dev
+SSL_EMAIL=admin@harmoni-360.fly.dev
+
+# =============================================================================
+# BACKUP CONFIGURATION
+# =============================================================================
+# Backup retention settings
+BACKUP_RETENTION_DAYS=30
+BACKUP_SCHEDULE="0 2 * * *"  # Daily at 2 AM
+
+# =============================================================================
+# SECURITY CONFIGURATION
+# =============================================================================
+# Allowed hosts (comma-separated)
+ALLOWED_HOSTS=harmoni-360.fly.dev,localhost
+
+# CORS origins for production (comma-separated)
+CORS_ORIGINS=https://harmoni-360.fly.dev
+
+# =============================================================================
+# PERFORMANCE CONFIGURATION
+# =============================================================================
+# Application performance settings
+ASPNETCORE_THREADPOOL_MINTHREADS=50
+ASPNETCORE_THREADPOOL_MAXTHREADS=200
+
+# =============================================================================
+# NOTIFICATION CONFIGURATION
+# =============================================================================
+# Email settings for notifications (optional)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=smtp-user
+SMTP_PASSWORD=OoEF9JssF5BRhqaXfQ9Jfd7jTRJYvZy3QQDpHNrNzCU=
+SMTP_FROM_EMAIL=noreply@your-domain.com
+SMTP_FROM_NAME=Harmoni360
+
+# =============================================================================
+# EXTERNAL SERVICES (Optional)
+# =============================================================================
+# Cloud backup settings (optional)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_BUCKET=
+AWS_REGION=us-east-1
+
+# =============================================================================
+# DEVELOPMENT/DEBUG (Set to false in production)
+# =============================================================================
+ENABLE_SWAGGER=false
+ENABLE_DETAILED_ERRORS=false
+ENABLE_DEVELOPER_EXCEPTION_PAGE=false

--- a/docs/Deployment/Fly_io_Deployment_Guide.md
+++ b/docs/Deployment/Fly_io_Deployment_Guide.md
@@ -280,6 +280,13 @@ fly volumes create harmoni360_uploads --region sjc --size 1
    fly secrets set Jwt__Key="YourSuperSecretProductionJwtKeyThatMustBeAtLeast32CharactersLong!"
    ```
 
+4. **Set Domain Variables (optional):**
+   ```bash
+   fly secrets set DOMAIN_NAME="harmoni-360.fly.dev"
+   fly secrets set ALLOWED_HOSTS="harmoni-360.fly.dev,localhost"
+   fly secrets set CORS_ORIGINS="https://harmoni-360.fly.dev"
+   ```
+
 ### 4.4 Deploy Application
 
 1. **Build and Deploy:**


### PR DESCRIPTION
## Summary
- configure default Fly domain in `.env.prod`
- document Fly secrets for DOMAIN_NAME and CORS settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c2b29d48083278e837bb76b917fe8