### PR TITLE
Add waste management provider basics

### DIFF
--- a/Harmoni360.sln
+++ b/Harmoni360.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmoni360.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmoni360.Web", "src\Harmoni360.Web\Harmoni360.Web.csproj", "{D2559F1B-D53B-4AFD-B494-24E83F401F0A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmoni360.Application.Tests", "tests\Harmoni360.Application.Tests\Harmoni360.Application.Tests.csproj", "{A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmoni360.Web.IntegrationTests", "tests\Harmoni360.Web.IntegrationTests\IntegrationTests.csproj", "{B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,11 +42,21 @@ Global
 		{D2559F1B-D53B-4AFD-B494-24E83F401F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2559F1B-D53B-4AFD-B494-24E83F401F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2559F1B-D53B-4AFD-B494-24E83F401F0A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{86CCF569-6141-476C-9CCE-6D727B8CD801} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
 		{F028C991-BF92-4898-BED4-D667C7828680} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
 		{39ABC374-6D28-44EF-890E-08949C7B5B59} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
 		{D2559F1B-D53B-4AFD-B494-24E83F401F0A} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
+                {A0A0A0A0-A0A0-A0A0-A0A0-A0A0A0A0A0A0} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
+                {B0B0B0B0-B0B0-B0B0-B0B0-B0B0B0B0B0B0} = {4BA95578-6B9D-45F7-8856-5521CC36E904}
 	EndGlobalSection
 EndGlobal

--- a/docs/Architecture/Waste_Management_System_Implementation_Plan.md
+++ b/docs/Architecture/Waste_Management_System_Implementation_Plan.md
@@ -1,0 +1,738 @@
+# Waste Management System Implementation Plan
+
+## Executive Summary
+
+This document provides a comprehensive implementation plan for the Waste Management System for the Harmoni360 application. The Waste Management module will enable comprehensive tracking, management, and compliance monitoring of waste generation, classification, handling, and disposal processes, expanding the current HSE scope to include the full HSSE (Health, Safety, Security, Environment) solution.
+
+## System Overview
+
+### Core Objectives
+- **Waste Report Submission**: Enable staff to report waste generation incidents and quantities
+- **Waste Classification**: Categorize waste types (hazardous, non-hazardous, recyclable, etc.)
+- **Disposal Tracking**: Track waste from generation through final disposal
+- **Document Management**: Attach and manage disposal certificates, manifests, and photos
+- **Compliance Monitoring**: Ensure regulatory compliance and reporting
+- **Integration with HSSE**: Connect with existing incident management and safety protocols
+- **Analytics & Reporting**: Provide insights into waste generation patterns and costs
+
+### Key Features
+1. **Waste Report Creation & Management**
+2. **Waste Classification System**
+3. **Disposal Provider Management**
+4. **Document Attachment System**
+5. **Compliance Dashboard**
+6. **Waste Tracking Workflow**
+7. **Integration with Incident Management**
+8. **Mobile Support for Field Reporting**
+
+## Technical Architecture
+
+### Domain Entities
+
+```csharp
+// Core Entities
+public class WasteReport : BaseEntity, IAuditableEntity
+{
+    public string ReportNumber { get; private set; }
+    public int ReporterId { get; private set; }
+    public User Reporter { get; private set; }
+    public DateTime ReportDate { get; private set; }
+    public int LocationId { get; private set; }
+    public Location Location { get; private set; }
+    public int DepartmentId { get; private set; }
+    public Department Department { get; private set; }
+    public int WasteCategoryId { get; private set; }
+    public WasteCategory WasteCategory { get; private set; }
+    public int WasteTypeId { get; private set; }
+    public WasteType WasteType { get; private set; }
+    public decimal Quantity { get; private set; }
+    public UnitOfMeasure Unit { get; private set; }
+    public string Description { get; private set; }
+    public WasteSource Source { get; private set; }
+    public string? SourceDetails { get; private set; }
+    public bool IsHazardous { get; private set; }
+    public string? HazardClassification { get; private set; }
+    public WasteReportStatus Status { get; private set; }
+    public DateTime? DisposalDate { get; private set; }
+    public int? DisposalProviderId { get; private set; }
+    public DisposalProvider? DisposalProvider { get; private set; }
+    public string? DisposalMethod { get; private set; }
+    public string? DisposalReferenceNumber { get; private set; }
+    public decimal? DisposalCost { get; private set; }
+    public string? RegulatoryCompliance { get; private set; }
+    public int? RelatedIncidentId { get; private set; }
+    public Incident? RelatedIncident { get; private set; }
+    
+    // Navigation properties
+    public virtual ICollection<WasteAttachment> Attachments { get; private set; }
+    public virtual ICollection<WasteDisposalRecord> DisposalRecords { get; private set; }
+    public virtual ICollection<WasteComment> Comments { get; private set; }
+}
+
+public class WasteCategory : BaseEntity, IAuditableEntity
+{
+    public string Name { get; private set; }
+    public string Code { get; private set; }
+    public string Description { get; private set; }
+    public WasteClassification Classification { get; private set; }
+    public bool RequiresSpecialHandling { get; private set; }
+    public bool RequiresManifest { get; private set; }
+    public string? HandlingInstructions { get; private set; }
+    public string? RegulatoryRequirements { get; private set; }
+    public string? DisposalGuidelines { get; private set; }
+    public bool IsActive { get; private set; }
+    
+    // Navigation properties
+    public virtual ICollection<WasteType> WasteTypes { get; private set; }
+}
+
+public class WasteType : BaseEntity, IAuditableEntity
+{
+    public string Name { get; private set; }
+    public string Code { get; private set; }
+    public string Description { get; private set; }
+    public int CategoryId { get; private set; }
+    public WasteCategory Category { get; private set; }
+    public string? WasteCode { get; private set; } // Regulatory waste code
+    public string? UNNumber { get; private set; } // For hazardous waste
+    public string? PhysicalState { get; private set; }
+    public bool IsRecyclable { get; private set; }
+    public string? RecyclingInstructions { get; private set; }
+    public string? StorageRequirements { get; private set; }
+    public int? MaxStorageDays { get; private set; }
+    public bool IsActive { get; private set; }
+}
+
+public class DisposalProvider : BaseEntity, IAuditableEntity
+{
+    public string Name { get; private set; }
+    public string Code { get; private set; }
+    public string LicenseNumber { get; private set; }
+    public DateTime LicenseExpiryDate { get; private set; }
+    public string ContactPerson { get; private set; }
+    public string ContactPhone { get; private set; }
+    public string ContactEmail { get; private set; }
+    public string Address { get; private set; }
+    public List<WasteClassification> AcceptedWasteTypes { get; private set; }
+    public List<string> Certifications { get; private set; }
+    public ProviderStatus Status { get; private set; }
+    public decimal? BaseRate { get; private set; }
+    public string? RateUnit { get; private set; }
+    public string? Notes { get; private set; }
+    
+    // Navigation properties
+    public virtual ICollection<WasteDisposalRecord> DisposalRecords { get; private set; }
+}
+
+public class WasteDisposalRecord : BaseEntity, IAuditableEntity
+{
+    public int WasteReportId { get; private set; }
+    public WasteReport WasteReport { get; private set; }
+    public int DisposalProviderId { get; private set; }
+    public DisposalProvider DisposalProvider { get; private set; }
+    public DateTime PickupDate { get; private set; }
+    public DateTime DisposalDate { get; private set; }
+    public string ManifestNumber { get; private set; }
+    public decimal ActualQuantity { get; private set; }
+    public UnitOfMeasure Unit { get; private set; }
+    public string DisposalMethod { get; private set; }
+    public string FacilityName { get; private set; }
+    public string? FacilityAddress { get; private set; }
+    public decimal Cost { get; private set; }
+    public string? InvoiceNumber { get; private set; }
+    public DisposalStatus Status { get; private set; }
+    public string? CertificateNumber { get; private set; }
+    public DateTime? CertificateDate { get; private set; }
+    public string? RegulatoryApproval { get; private set; }
+    public string? Notes { get; private set; }
+}
+
+public class WasteAttachment : BaseEntity, IAuditableEntity
+{
+    public int WasteReportId { get; private set; }
+    public WasteReport WasteReport { get; private set; }
+    public string FileName { get; private set; }
+    public string FilePath { get; private set; }
+    public long FileSize { get; private set; }
+    public string ContentType { get; private set; }
+    public AttachmentType Type { get; private set; }
+    public string? Description { get; private set; }
+    public int UploadedById { get; private set; }
+    public User UploadedBy { get; private set; }
+    public DateTime UploadedDate { get; private set; }
+}
+
+public class WasteComment : BaseEntity, IAuditableEntity
+{
+    public int WasteReportId { get; private set; }
+    public WasteReport WasteReport { get; private set; }
+    public string Comment { get; private set; }
+    public int CommentedById { get; private set; }
+    public User CommentedBy { get; private set; }
+    public DateTime CommentedDate { get; private set; }
+    public CommentType Type { get; private set; }
+}
+
+public class WasteCompliance : BaseEntity, IAuditableEntity
+{
+    public string RegulatoryBody { get; private set; }
+    public string RegulationCode { get; private set; }
+    public string RegulationName { get; private set; }
+    public string Description { get; private set; }
+    public List<WasteClassification> ApplicableWasteTypes { get; private set; }
+    public string ComplianceRequirements { get; private set; }
+    public int ReportingFrequencyDays { get; private set; }
+    public DateTime? LastReportDate { get; private set; }
+    public DateTime NextReportDueDate { get; private set; }
+    public ComplianceStatus Status { get; private set; }
+    public bool IsActive { get; private set; }
+}
+```
+
+### Value Objects
+
+```csharp
+public class WasteQuantity : ValueObject
+{
+    public decimal Amount { get; private set; }
+    public UnitOfMeasure Unit { get; private set; }
+    public decimal? ConvertedToKg { get; private set; }
+    public decimal? ConvertedToLiters { get; private set; }
+}
+
+public class DisposalCertificate : ValueObject
+{
+    public string CertificateNumber { get; private set; }
+    public DateTime IssueDate { get; private set; }
+    public string IssuingAuthority { get; private set; }
+    public DateTime? ExpiryDate { get; private set; }
+    public string VerificationUrl { get; private set; }
+}
+```
+
+### Enumerations
+
+```csharp
+public enum WasteClassification
+{
+    NonHazardous = 1,
+    HazardousChemical = 2,
+    HazardousBiological = 3,
+    HazardousRadioactive = 4,
+    Recyclable = 5,
+    Organic = 6,
+    Electronic = 7,
+    Construction = 8,
+    Medical = 9,
+    Universal = 10
+}
+
+public enum WasteSource
+{
+    Laboratory = 1,
+    Cafeteria = 2,
+    Office = 3,
+    Maintenance = 4,
+    Construction = 5,
+    Medical = 6,
+    Classroom = 7,
+    Event = 8,
+    Other = 9
+}
+
+public enum UnitOfMeasure
+{
+    Kilogram = 1,
+    Liter = 2,
+    CubicMeter = 3,
+    Ton = 4,
+    Gallon = 5,
+    Pound = 6,
+    Unit = 7,
+    Container = 8
+}
+
+public enum WasteReportStatus
+{
+    Draft = 1,
+    Submitted = 2,
+    UnderReview = 3,
+    Approved = 4,
+    InStorage = 5,
+    AwaitingPickup = 6,
+    InTransit = 7,
+    Disposed = 8,
+    Rejected = 9,
+    Cancelled = 10
+}
+
+public enum DisposalStatus
+{
+    Scheduled = 1,
+    InProgress = 2,
+    Completed = 3,
+    CertificatePending = 4,
+    Certified = 5,
+    Failed = 6
+}
+
+public enum AttachmentType
+{
+    Photo = 1,
+    Manifest = 2,
+    Certificate = 3,
+    Invoice = 4,
+    Permit = 5,
+    Report = 6,
+    Other = 7
+}
+
+public enum CommentType
+{
+    General = 1,
+    StatusUpdate = 2,
+    ComplianceNote = 3,
+    DisposalUpdate = 4,
+    Correction = 5
+}
+
+public enum ProviderStatus
+{
+    Active = 1,
+    Suspended = 2,
+    Expired = 3,
+    UnderReview = 4,
+    Terminated = 5
+}
+
+public enum ComplianceStatus
+{
+    Compliant = 1,
+    NonCompliant = 2,
+    PendingReview = 3,
+    Overdue = 4
+}
+```
+
+## API Endpoints
+
+### Waste Report Management
+```
+GET    /api/waste-reports                    - Get waste reports with filtering/pagination
+POST   /api/waste-reports                    - Create new waste report
+GET    /api/waste-reports/{id}               - Get specific waste report
+PUT    /api/waste-reports/{id}               - Update waste report
+DELETE /api/waste-reports/{id}               - Delete waste report (soft delete)
+GET    /api/waste-reports/my                 - Get user's waste reports
+```
+
+### Waste Report Operations
+```
+POST   /api/waste-reports/{id}/submit        - Submit draft report for review
+POST   /api/waste-reports/{id}/approve       - Approve waste report
+POST   /api/waste-reports/{id}/reject        - Reject waste report
+POST   /api/waste-reports/{id}/dispose       - Record disposal
+POST   /api/waste-reports/{id}/cancel        - Cancel waste report
+```
+
+### Document Management
+```
+GET    /api/waste-reports/{id}/attachments   - Get report attachments
+POST   /api/waste-reports/{id}/attachments   - Upload attachment
+GET    /api/waste-reports/attachments/{id}   - Download attachment
+DELETE /api/waste-reports/attachments/{id}   - Delete attachment
+```
+
+### Comments
+```
+GET    /api/waste-reports/{id}/comments      - Get report comments
+POST   /api/waste-reports/{id}/comments      - Add comment
+```
+
+### Disposal Management
+```
+GET    /api/waste/disposal-providers         - Get disposal providers
+POST   /api/waste/disposal-providers         - Create disposal provider
+PUT    /api/waste/disposal-providers/{id}    - Update disposal provider
+DELETE /api/waste/disposal-providers/{id}    - Delete disposal provider
+GET    /api/waste/disposal-records           - Get disposal records
+POST   /api/waste/disposal-records           - Create disposal record
+```
+
+### Analytics & Reporting
+```
+GET    /api/waste/dashboard                  - Get dashboard metrics
+GET    /api/waste/analytics/trends           - Get waste generation trends
+GET    /api/waste/analytics/by-category      - Get waste by category
+GET    /api/waste/analytics/costs            - Get disposal cost analysis
+GET    /api/waste/compliance/status          - Get compliance status
+GET    /api/waste/reports/summary            - Get summary reports
+```
+
+### Configuration
+```
+GET    /api/waste/categories                 - Get waste categories
+POST   /api/waste/categories                 - Create waste category
+PUT    /api/waste/categories/{id}            - Update waste category
+DELETE /api/waste/categories/{id}            - Delete waste category
+
+GET    /api/waste/types                      - Get waste types
+POST   /api/waste/types                      - Create waste type
+PUT    /api/waste/types/{id}                 - Update waste type
+DELETE /api/waste/types/{id}                 - Delete waste type
+```
+
+## Application Layer Commands & Queries
+
+### Commands
+```csharp
+// Waste Report Management
+public record CreateWasteReportCommand : IRequest<WasteReportDto>
+{
+    public int LocationId { get; init; }
+    public int DepartmentId { get; init; }
+    public int WasteCategoryId { get; init; }
+    public int WasteTypeId { get; init; }
+    public decimal Quantity { get; init; }
+    public UnitOfMeasure Unit { get; init; }
+    public string Description { get; init; }
+    public WasteSource Source { get; init; }
+    public string? SourceDetails { get; init; }
+    public bool IsHazardous { get; init; }
+    public string? HazardClassification { get; init; }
+    public int? RelatedIncidentId { get; init; }
+}
+
+public record UpdateWasteReportCommand : IRequest<WasteReportDto>
+public record DeleteWasteReportCommand : IRequest<Unit>
+public record SubmitWasteReportCommand : IRequest<Unit>
+public record ApproveWasteReportCommand : IRequest<Unit>
+public record RejectWasteReportCommand : IRequest<Unit>
+
+// Disposal Management
+public record RecordDisposalCommand : IRequest<WasteDisposalRecordDto>
+public record UpdateDisposalRecordCommand : IRequest<WasteDisposalRecordDto>
+
+// Attachment Management
+public record UploadWasteAttachmentCommand : IRequest<WasteAttachmentDto>
+public record DeleteWasteAttachmentCommand : IRequest<Unit>
+
+// Comment Management
+public record AddWasteCommentCommand : IRequest<WasteCommentDto>
+```
+
+### Queries
+```csharp
+// Waste Reports
+public record GetWasteReportsQuery : IRequest<PaginatedList<WasteReportDto>>
+{
+    public WasteReportStatus? Status { get; init; }
+    public int? CategoryId { get; init; }
+    public int? TypeId { get; init; }
+    public DateTime? StartDate { get; init; }
+    public DateTime? EndDate { get; init; }
+    public string? SearchTerm { get; init; }
+    public int PageNumber { get; init; }
+    public int PageSize { get; init; }
+}
+
+public record GetWasteReportByIdQuery : IRequest<WasteReportDetailDto>
+public record GetMyWasteReportsQuery : IRequest<List<WasteReportDto>>
+
+// Analytics
+public record GetWasteDashboardQuery : IRequest<WasteDashboardDto>
+public record GetWasteTrendsQuery : IRequest<WasteTrendsDto>
+public record GetWasteCostAnalysisQuery : IRequest<WasteCostAnalysisDto>
+public record GetComplianceStatusQuery : IRequest<ComplianceStatusDto>
+
+// Configuration
+public record GetWasteCategoriesQuery : IRequest<List<WasteCategoryDto>>
+public record GetWasteTypesQuery : IRequest<List<WasteTypeDto>>
+public record GetDisposalProvidersQuery : IRequest<List<DisposalProviderDto>>
+```
+
+## Frontend Components
+
+### Page Structure
+```
+src/Harmoni360.Web/ClientApp/src/pages/waste-management/
+├── WasteDashboard.tsx
+├── WasteReportList.tsx
+├── CreateWasteReport.tsx
+├── EditWasteReport.tsx
+├── WasteReportDetail.tsx
+├── MyWasteReports.tsx
+├── DisposalProviders.tsx
+├── ComplianceDashboard.tsx
+└── index.ts
+```
+
+### Core Views
+
+1. **Waste Dashboard** (/waste-management/dashboard)
+   - Overview metrics (Total reports, Pending disposal, This month's volume)
+   - Waste classification breakdown chart
+   - Recent waste reports table
+   - Compliance status indicators
+   - Quick actions (New report, View pending)
+   - Cost analysis widget
+
+2. **Waste Report List** (/waste-management)
+   - Advanced filtering (status, category, date range, location)
+   - Search functionality
+   - Pagination with configurable page size
+   - Quick actions (View, Edit, Download)
+   - Export to Excel/PDF
+   - Bulk operations support
+
+3. **Create Waste Report** (/waste-management/create)
+   - Multi-step form wizard
+   - Basic Information (location, department, date)
+   - Waste Details (category, type, quantity, source)
+   - Hazard Classification (if applicable)
+   - Related Incident linkage
+   - File upload for photos/documents
+   - Save as draft functionality
+
+4. **Waste Report Detail** (/waste-management/:id)
+   - Complete report information
+   - Status workflow actions
+   - Disposal records
+   - Attached documents gallery
+   - Comments/activity timeline
+   - Print-friendly view
+   - QR code for mobile access
+
+5. **My Waste Reports** (/waste-management/my-reports)
+   - User's submitted reports
+   - Draft reports
+   - Status filtering
+   - Quick edit access
+   - Performance metrics
+
+6. **Disposal Providers** (/waste-management/providers)
+   - Provider listing with search
+   - License status indicators
+   - Accepted waste types
+   - Contact information
+   - Performance ratings
+   - Add/Edit provider forms
+
+7. **Compliance Dashboard** (/waste-management/compliance)
+   - Regulatory compliance status
+   - Upcoming reporting deadlines
+   - Non-compliance alerts
+   - Audit trail
+   - Report generation
+   - Compliance trends
+
+### Component Library
+
+```typescript
+// Common components
+src/Harmoni360.Web/ClientApp/src/components/waste-management/
+├── WasteReportForm.tsx
+├── WasteAttachmentManager.tsx
+├── DisposalRecordCard.tsx
+├── ComplianceIndicator.tsx
+├── WasteClassificationBadge.tsx
+├── DisposalProviderSelector.tsx
+├── WasteQuantityInput.tsx
+├── WasteTrendChart.tsx
+└── index.ts
+```
+
+## Database Schema
+
+### Tables
+
+1. **WasteReports**
+   - Primary tracking table for all waste reports
+   - Foreign keys to Users, Locations, Departments
+   - Audit fields for tracking changes
+
+2. **WasteCategories**
+   - Master data for waste classifications
+   - Regulatory requirements per category
+   - Handling instructions
+
+3. **WasteTypes**
+   - Specific waste types under categories
+   - Regulatory codes and UN numbers
+   - Storage and recycling information
+
+4. **DisposalProviders**
+   - Licensed waste disposal companies
+   - Certification tracking
+   - Accepted waste types
+
+5. **WasteDisposalRecords**
+   - Disposal transaction records
+   - Manifest and certificate tracking
+   - Cost information
+
+6. **WasteAttachments**
+   - Document storage for reports
+   - Support for multiple file types
+   - Secure file access
+
+7. **WasteComments**
+   - Activity tracking
+   - Status change history
+   - User communications
+
+8. **WasteCompliance**
+   - Regulatory requirements
+   - Reporting schedules
+   - Compliance tracking
+
+### Indexes
+```sql
+-- Performance indexes
+CREATE INDEX IX_WasteReports_Status ON WasteReports(Status);
+CREATE INDEX IX_WasteReports_ReportDate ON WasteReports(ReportDate);
+CREATE INDEX IX_WasteReports_CategoryId ON WasteReports(WasteCategoryId);
+CREATE INDEX IX_WasteDisposalRecords_DisposalDate ON WasteDisposalRecords(DisposalDate);
+CREATE INDEX IX_WasteAttachments_WasteReportId ON WasteAttachments(WasteReportId);
+```
+
+## Integration Points
+
+### HSSE Module Integration
+
+1. **Incident Management**
+   - Link waste reports to incidents
+   - Automatic waste report creation from spill incidents
+   - Cross-reference in reporting
+
+2. **Safety Protocols**
+   - PPE requirements for waste handling
+   - Safety procedure references
+   - Training requirements
+
+3. **Risk Assessment**
+   - Waste-related risk identification
+   - Mitigation measures tracking
+   - Environmental impact assessment
+
+4. **Audit Management**
+   - Waste management audit items
+   - Compliance verification
+   - Corrective action tracking
+
+### System Integration
+
+1. **Authentication & Authorization**
+   - Role-based access control
+   - Department-based visibility
+   - Approval workflow permissions
+
+2. **Notification System**
+   - Email alerts for approvals
+   - SMS for urgent disposals
+   - Dashboard notifications
+
+3. **Reporting Engine**
+   - Monthly waste reports
+   - Regulatory compliance reports
+   - Cost analysis reports
+
+## Implementation Phases
+
+### Phase 1: Core Foundation (Week 1-2)
+- [ ] Domain entities and value objects
+- [ ] Database schema and migrations
+- [ ] Basic CRUD operations
+- [ ] File upload infrastructure
+
+### Phase 2: Basic UI (Week 3-4)
+- [ ] Waste report listing page
+- [ ] Create/Edit waste report forms
+- [ ] Basic dashboard
+- [ ] File attachment UI
+
+### Phase 3: Workflow Implementation (Week 5-6)
+- [ ] Status workflow engine
+- [ ] Approval process
+- [ ] Disposal recording
+- [ ] Email notifications
+
+### Phase 4: Configuration Management (Week 7)
+- [ ] Waste categories and types management
+- [ ] Disposal provider management
+- [ ] System settings
+
+### Phase 5: Analytics & Reporting (Week 8-9)
+- [ ] Dashboard analytics
+- [ ] Trend analysis
+- [ ] Cost tracking
+- [ ] Report generation
+
+### Phase 6: Compliance & Integration (Week 10-11)
+- [ ] Compliance monitoring
+- [ ] HSSE integration
+- [ ] Mobile optimization
+- [ ] Performance tuning
+
+### Phase 7: Testing & Documentation (Week 12)
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] User documentation
+- [ ] Deployment preparation
+
+## Security Considerations
+
+1. **Data Access**
+   - Department-based data isolation
+   - Role-based feature access
+   - Audit trail for all changes
+
+2. **File Security**
+   - Virus scanning for uploads
+   - Secure file storage
+   - Access control for downloads
+
+3. **Compliance**
+   - Data retention policies
+   - Privacy protection
+   - Regulatory requirements
+
+## Performance Requirements
+
+1. **Response Times**
+   - Page load < 2 seconds
+   - API response < 500ms
+   - File upload < 30 seconds
+
+2. **Scalability**
+   - Support 1000+ reports/month
+   - Handle 50+ concurrent users
+   - Store 10GB+ attachments
+
+3. **Availability**
+   - 99.9% uptime target
+   - Disaster recovery plan
+   - Regular backups
+
+## Success Metrics
+
+1. **Adoption Metrics**
+   - 90% waste report submission rate
+   - 80% user adoption in 3 months
+   - 95% disposal tracking accuracy
+
+2. **Compliance Metrics**
+   - 100% regulatory report submission
+   - 0 compliance violations
+   - 90% on-time disposal rate
+
+3. **Efficiency Metrics**
+   - 50% reduction in paper forms
+   - 30% faster report processing
+   - 40% cost reduction through analytics
+
+## Conclusion
+
+The Waste Management System will provide Harmoni360 with a comprehensive solution for tracking and managing waste from generation through disposal. By following the established architectural patterns and integrating seamlessly with existing HSSE modules, the system will enhance environmental compliance, reduce costs, and improve operational efficiency.
+
+The modular design ensures future extensibility while maintaining consistency with the Harmoni360 platform standards. With proper implementation of the outlined features, the system will meet all regulatory requirements while providing an intuitive user experience for staff at all levels.

--- a/src/Harmoni360.Application/Common/Interfaces/IAntivirusScanner.cs
+++ b/src/Harmoni360.Application/Common/Interfaces/IAntivirusScanner.cs
@@ -1,0 +1,7 @@
+using System.IO;
+namespace Harmoni360.Application.Common.Interfaces;
+
+public interface IAntivirusScanner
+{
+    Task ScanAsync(Stream fileStream, CancellationToken cancellationToken = default);
+}

--- a/src/Harmoni360.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Harmoni360.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Harmoni360.Domain.Entities;
 using Harmoni360.Domain.Entities.Security;
 using Harmoni360.Domain.Entities.Inspections;
+using Harmoni360.Domain.Entities.Waste;
 using Microsoft.EntityFrameworkCore;
 
 namespace Harmoni360.Application.Common.Interfaces;
@@ -74,6 +75,15 @@ public interface IApplicationDbContext
     DbSet<InspectionAttachment> InspectionAttachments { get; }
     DbSet<InspectionComment> InspectionComments { get; }
     DbSet<FindingAttachment> FindingAttachments { get; }
+
+    // Waste Management
+    DbSet<WasteReport> WasteReports { get; }
+    DbSet<WasteAttachment> WasteAttachments { get; }
+    DbSet<WasteType> WasteTypes { get; }
+    DbSet<DisposalProvider> DisposalProviders { get; }
+    DbSet<WasteDisposalRecord> WasteDisposalRecords { get; }
+    DbSet<WasteComment> WasteComments { get; }
+    DbSet<WasteCompliance> WasteCompliances { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Harmoni360.Application/DependencyInjection.cs
+++ b/src/Harmoni360.Application/DependencyInjection.cs
@@ -29,6 +29,7 @@ public static class DependencyInjection
 
         // Add module-specific services
         services.AddIncidentModule();
+        services.AddWasteModule();
 
         return services;
     }
@@ -40,6 +41,12 @@ public static class DependencyInjection
         services.AddScoped<IIncidentCacheService, IncidentCacheService>();
 
         // Register incident-specific services here
+        return services;
+    }
+
+    private static IServiceCollection AddWasteModule(this IServiceCollection services)
+    {
+        // Placeholder for future waste-specific services
         return services;
     }
 }

--- a/src/Harmoni360.Application/Features/DisposalProviders/Commands/CreateDisposalProviderCommand.cs
+++ b/src/Harmoni360.Application/Features/DisposalProviders/Commands/CreateDisposalProviderCommand.cs
@@ -1,0 +1,6 @@
+using Harmoni360.Application.Features.DisposalProviders.DTOs;
+using MediatR;
+
+namespace Harmoni360.Application.Features.DisposalProviders.Commands;
+
+public record CreateDisposalProviderCommand(string Name, string LicenseNumber, DateTime LicenseExpiryDate) : IRequest<DisposalProviderDto>;

--- a/src/Harmoni360.Application/Features/DisposalProviders/Commands/CreateDisposalProviderCommandHandler.cs
+++ b/src/Harmoni360.Application/Features/DisposalProviders/Commands/CreateDisposalProviderCommandHandler.cs
@@ -1,0 +1,33 @@
+using Harmoni360.Application.Common.Interfaces;
+using Harmoni360.Application.Features.DisposalProviders.DTOs;
+using Harmoni360.Domain.Entities.Waste;
+using MediatR;
+
+namespace Harmoni360.Application.Features.DisposalProviders.Commands;
+
+public class CreateDisposalProviderCommandHandler : IRequestHandler<CreateDisposalProviderCommand, DisposalProviderDto>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUser;
+
+    public CreateDisposalProviderCommandHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+    {
+        _context = context;
+        _currentUser = currentUser;
+    }
+
+    public async Task<DisposalProviderDto> Handle(CreateDisposalProviderCommand request, CancellationToken cancellationToken)
+    {
+        var entity = DisposalProvider.Create(request.Name, request.LicenseNumber, request.LicenseExpiryDate, _currentUser.Email);
+        _context.DisposalProviders.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return new DisposalProviderDto
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            LicenseNumber = entity.LicenseNumber,
+            LicenseExpiryDate = entity.LicenseExpiryDate
+        };
+    }
+}

--- a/src/Harmoni360.Application/Features/DisposalProviders/DTOs/DisposalProviderDto.cs
+++ b/src/Harmoni360.Application/Features/DisposalProviders/DTOs/DisposalProviderDto.cs
@@ -1,0 +1,9 @@
+namespace Harmoni360.Application.Features.DisposalProviders.DTOs;
+
+public class DisposalProviderDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string LicenseNumber { get; set; } = string.Empty;
+    public DateTime LicenseExpiryDate { get; set; }
+}

--- a/src/Harmoni360.Application/Features/DisposalProviders/Queries/GetDisposalProvidersQuery.cs
+++ b/src/Harmoni360.Application/Features/DisposalProviders/Queries/GetDisposalProvidersQuery.cs
@@ -1,0 +1,6 @@
+using Harmoni360.Application.Features.DisposalProviders.DTOs;
+using MediatR;
+
+namespace Harmoni360.Application.Features.DisposalProviders.Queries;
+
+public record GetDisposalProvidersQuery : IRequest<List<DisposalProviderDto>>;

--- a/src/Harmoni360.Application/Features/DisposalProviders/Queries/GetDisposalProvidersQueryHandler.cs
+++ b/src/Harmoni360.Application/Features/DisposalProviders/Queries/GetDisposalProvidersQueryHandler.cs
@@ -1,0 +1,30 @@
+using Harmoni360.Application.Common.Interfaces;
+using Harmoni360.Application.Features.DisposalProviders.DTOs;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Harmoni360.Application.Features.DisposalProviders.Queries;
+
+public class GetDisposalProvidersQueryHandler : IRequestHandler<GetDisposalProvidersQuery, List<DisposalProviderDto>>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetDisposalProvidersQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<DisposalProviderDto>> Handle(GetDisposalProvidersQuery request, CancellationToken cancellationToken)
+    {
+        return await _context.DisposalProviders
+            .Where(p => p.IsActive)
+            .Select(p => new DisposalProviderDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                LicenseNumber = p.LicenseNumber,
+                LicenseExpiryDate = p.LicenseExpiryDate
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/Harmoni360.Application/Features/WasteReports/Commands/CreateWasteReportCommand.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Commands/CreateWasteReportCommand.cs
@@ -1,0 +1,17 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Harmoni360.Domain.Entities.Waste;
+using Harmoni360.Application.Features.WasteReports.DTOs;
+
+namespace Harmoni360.Application.Features.WasteReports.Commands;
+
+public record CreateWasteReportCommand : IRequest<WasteReportDto>
+{
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public WasteCategory Category { get; init; }
+    public DateTime GeneratedDate { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public int? ReporterId { get; init; }
+    public List<IFormFile> Attachments { get; init; } = new();
+}

--- a/src/Harmoni360.Application/Features/WasteReports/Commands/CreateWasteReportCommandHandler.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Commands/CreateWasteReportCommandHandler.cs
@@ -1,0 +1,62 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Harmoni360.Application.Common.Interfaces;
+using Harmoni360.Application.Features.WasteReports.DTOs;
+using Harmoni360.Domain.Entities.Waste;
+
+public class CreateWasteReportCommandHandler : IRequestHandler<CreateWasteReportCommand, WasteReportDto>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IFileStorageService _fileStorageService;
+    private readonly IAntivirusScanner _antivirusScanner;
+
+    public CreateWasteReportCommandHandler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IFileStorageService fileStorageService,
+        IAntivirusScanner antivirusScanner)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _fileStorageService = fileStorageService;
+        _antivirusScanner = antivirusScanner;
+    }
+
+    public async Task<WasteReportDto> Handle(CreateWasteReportCommand request, CancellationToken cancellationToken)
+    {
+        var reporter = request.ReporterId.HasValue ? await _context.Users.FirstOrDefaultAsync(u => u.Id == request.ReporterId.Value, cancellationToken) : null;
+
+        var waste = WasteReport.Create(request.Title, request.Description, request.Category, request.GeneratedDate, request.Location, request.ReporterId, _currentUserService.Email);
+        _context.Add(waste);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        if (request.Attachments.Any())
+        {
+            foreach (var file in request.Attachments)
+            {
+                await _antivirusScanner.ScanAsync(file.OpenReadStream(), cancellationToken);
+                var upload = await _fileStorageService.UploadAsync(
+                    file.OpenReadStream(),
+                    file.FileName,
+                    file.ContentType,
+                    "waste");
+                waste.AddAttachment(file.FileName, upload.FilePath, file.Length, _currentUserService.Email);
+            }
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        return new WasteReportDto
+        {
+            Id = waste.Id,
+            Title = waste.Title,
+            Description = waste.Description,
+            Category = waste.Category.ToString(),
+            GeneratedDate = waste.GeneratedDate,
+            Location = waste.Location,
+            ReporterId = waste.ReporterId,
+            ReporterName = reporter?.Name,
+            AttachmentsCount = waste.Attachments.Count
+        };
+    }
+}

--- a/src/Harmoni360.Application/Features/WasteReports/Commands/UpdateDisposalStatusCommand.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Commands/UpdateDisposalStatusCommand.cs
@@ -1,0 +1,6 @@
+using Harmoni360.Domain.Entities.Waste;
+using MediatR;
+
+namespace Harmoni360.Application.Features.WasteReports.Commands;
+
+public record UpdateDisposalStatusCommand(int Id, WasteDisposalStatus Status) : IRequest;

--- a/src/Harmoni360.Application/Features/WasteReports/Commands/UpdateDisposalStatusCommandHandler.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Commands/UpdateDisposalStatusCommandHandler.cs
@@ -1,0 +1,25 @@
+using Harmoni360.Application.Common.Interfaces;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Harmoni360.Application.Features.WasteReports.Commands;
+
+public class UpdateDisposalStatusCommandHandler : IRequestHandler<UpdateDisposalStatusCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateDisposalStatusCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(UpdateDisposalStatusCommand request, CancellationToken cancellationToken)
+    {
+        var report = await _context.WasteReports.FirstOrDefaultAsync(w => w.Id == request.Id, cancellationToken);
+        if (report is null)
+        {
+            return;
+        }
+        report.UpdateDisposalStatus(request.Status);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Harmoni360.Application/Features/WasteReports/DTOs/WasteReportDto.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/DTOs/WasteReportDto.cs
@@ -1,0 +1,14 @@
+namespace Harmoni360.Application.Features.WasteReports.DTOs;
+
+public class WasteReportDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public DateTime GeneratedDate { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public int? ReporterId { get; set; }
+    public string? ReporterName { get; set; }
+    public int AttachmentsCount { get; set; }
+}

--- a/src/Harmoni360.Application/Features/WasteReports/Queries/GetWasteReportsQuery.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Queries/GetWasteReportsQuery.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using Harmoni360.Application.Features.WasteReports.DTOs;
+using Harmoni360.Domain.Entities.Waste;
+
+namespace Harmoni360.Application.Features.WasteReports.Queries;
+
+public record GetWasteReportsQuery(
+    WasteCategory? Category = null,
+    string? Search = null,
+    int Page = 1,
+    int PageSize = 20) : IRequest<List<WasteReportDto>>;

--- a/src/Harmoni360.Application/Features/WasteReports/Queries/GetWasteReportsQueryHandler.cs
+++ b/src/Harmoni360.Application/Features/WasteReports/Queries/GetWasteReportsQueryHandler.cs
@@ -1,0 +1,51 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Harmoni360.Application.Common.Interfaces;
+using Harmoni360.Application.Features.WasteReports.DTOs;
+
+namespace Harmoni360.Application.Features.WasteReports.Queries;
+
+public class GetWasteReportsQueryHandler : IRequestHandler<GetWasteReportsQuery, List<WasteReportDto>>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetWasteReportsQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<WasteReportDto>> Handle(GetWasteReportsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _context.WasteReports
+            .Include(w => w.Reporter)
+            .AsQueryable();
+
+        if (request.Category.HasValue)
+        {
+            query = query.Where(w => w.Category == request.Category.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            query = query.Where(w => w.Title.Contains(request.Search!) || w.Description.Contains(request.Search!));
+        }
+
+        return await query
+            .OrderByDescending(w => w.GeneratedDate)
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .Select(w => new WasteReportDto
+            {
+                Id = w.Id,
+                Title = w.Title,
+                Description = w.Description,
+                Category = w.Category.ToString(),
+                GeneratedDate = w.GeneratedDate,
+                Location = w.Location,
+                ReporterId = w.ReporterId,
+                ReporterName = w.Reporter != null ? w.Reporter.Name : null,
+                AttachmentsCount = w.Attachments.Count
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/DisposalProvider.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/DisposalProvider.cs
@@ -1,0 +1,46 @@
+using Harmoni360.Domain.Common;
+using Harmoni360.Domain.Enums;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class DisposalProvider : BaseEntity, IAuditableEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string LicenseNumber { get; private set; } = string.Empty;
+    public DateTime LicenseExpiryDate { get; private set; }
+    public ProviderStatus Status { get; private set; } = ProviderStatus.Active;
+    public bool IsActive { get; private set; } = true;
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected DisposalProvider() { }
+
+    public static DisposalProvider Create(string name, string licenseNumber, DateTime licenseExpiryDate, string createdBy)
+    {
+        return new DisposalProvider
+        {
+            Name = name,
+            LicenseNumber = licenseNumber,
+            LicenseExpiryDate = licenseExpiryDate,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void Update(string name, string licenseNumber, DateTime licenseExpiryDate)
+    {
+        Name = name;
+        LicenseNumber = licenseNumber;
+        LicenseExpiryDate = licenseExpiryDate;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+
+    public void ChangeStatus(ProviderStatus status)
+    {
+        Status = status;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteAttachment.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteAttachment.cs
@@ -1,0 +1,25 @@
+using Harmoni360.Domain.Common;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteAttachment : BaseEntity
+{
+    public int WasteReportId { get; private set; }
+    public string FileName { get; private set; } = string.Empty;
+    public string FilePath { get; private set; } = string.Empty;
+    public long FileSize { get; private set; }
+    public string UploadedBy { get; private set; } = string.Empty;
+    public DateTime UploadedAt { get; private set; }
+
+    protected WasteAttachment() { }
+
+    public WasteAttachment(int wasteReportId, string fileName, string filePath, long fileSize, string uploadedBy)
+    {
+        WasteReportId = wasteReportId;
+        FileName = fileName;
+        FilePath = filePath;
+        FileSize = fileSize;
+        UploadedBy = uploadedBy;
+        UploadedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteCategory.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteCategory.cs
@@ -1,0 +1,8 @@
+namespace Harmoni360.Domain.Entities.Waste;
+
+public enum WasteCategory
+{
+    Hazardous = 1,
+    NonHazardous = 2,
+    Recyclable = 3
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteComment.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteComment.cs
@@ -1,0 +1,34 @@
+using Harmoni360.Domain.Common;
+using Harmoni360.Domain.Enums;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteComment : BaseEntity, IAuditableEntity
+{
+    public int WasteReportId { get; private set; }
+    public WasteReport WasteReport { get; private set; } = null!;
+    public string Comment { get; private set; } = string.Empty;
+    public CommentType Type { get; private set; }
+    public int CommentedById { get; private set; }
+    public User CommentedBy { get; private set; } = null!;
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected WasteComment() { }
+
+    public static WasteComment Create(int wasteReportId, int commentedById, string comment, CommentType type, string createdBy)
+    {
+        return new WasteComment
+        {
+            WasteReportId = wasteReportId,
+            CommentedById = commentedById,
+            Comment = comment,
+            Type = type,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteCompliance.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteCompliance.cs
@@ -1,0 +1,38 @@
+using Harmoni360.Domain.Common;
+using Harmoni360.Domain.Enums;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteCompliance : BaseEntity, IAuditableEntity
+{
+    public string RegulatoryBody { get; private set; } = string.Empty;
+    public string RegulationCode { get; private set; } = string.Empty;
+    public string RegulationName { get; private set; } = string.Empty;
+    public ComplianceStatus Status { get; private set; } = ComplianceStatus.Compliant;
+    public bool IsActive { get; private set; } = true;
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected WasteCompliance() { }
+
+    public static WasteCompliance Create(string body, string code, string name, string createdBy)
+    {
+        return new WasteCompliance
+        {
+            RegulatoryBody = body,
+            RegulationCode = code,
+            RegulationName = name,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void ChangeStatus(ComplianceStatus status)
+    {
+        Status = status;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteDisposalRecord.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteDisposalRecord.cs
@@ -1,0 +1,44 @@
+using Harmoni360.Domain.Common;
+using Harmoni360.Domain.Enums;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteDisposalRecord : BaseEntity, IAuditableEntity
+{
+    public int WasteReportId { get; private set; }
+    public WasteReport WasteReport { get; private set; } = null!;
+    public int DisposalProviderId { get; private set; }
+    public DisposalProvider DisposalProvider { get; private set; } = null!;
+    public DateTime DisposalDate { get; private set; }
+    public decimal ActualQuantity { get; private set; }
+    public UnitOfMeasure Unit { get; private set; }
+    public DisposalStatus Status { get; private set; }
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected WasteDisposalRecord() { }
+
+    public static WasteDisposalRecord Create(int wasteReportId, int disposalProviderId, DateTime disposalDate, decimal quantity, UnitOfMeasure unit, string createdBy)
+    {
+        return new WasteDisposalRecord
+        {
+            WasteReportId = wasteReportId,
+            DisposalProviderId = disposalProviderId,
+            DisposalDate = disposalDate,
+            ActualQuantity = quantity,
+            Unit = unit,
+            Status = DisposalStatus.Scheduled,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void UpdateStatus(DisposalStatus status)
+    {
+        Status = status;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteDisposalStatus.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteDisposalStatus.cs
@@ -1,0 +1,8 @@
+namespace Harmoni360.Domain.Entities.Waste;
+
+public enum WasteDisposalStatus
+{
+    Pending = 1,
+    InProgress = 2,
+    Disposed = 3
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteReport.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteReport.cs
@@ -1,0 +1,52 @@
+using Harmoni360.Domain.Common;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteReport : BaseEntity, IAuditableEntity
+{
+    public string Title { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public WasteCategory Category { get; private set; }
+    public DateTime GeneratedDate { get; private set; }
+    public string Location { get; private set; } = string.Empty;
+
+    public WasteDisposalStatus DisposalStatus { get; private set; } = WasteDisposalStatus.Pending;
+
+    public int? ReporterId { get; private set; }
+    public User? Reporter { get; private set; }
+
+    private readonly List<WasteAttachment> _attachments = new();
+    public IReadOnlyCollection<WasteAttachment> Attachments => _attachments.AsReadOnly();
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected WasteReport() { }
+
+    public static WasteReport Create(string title, string description, WasteCategory category, DateTime generatedDate, string location, int? reporterId, string createdBy)
+    {
+        return new WasteReport
+        {
+            Title = title,
+            Description = description,
+            Category = category,
+            GeneratedDate = generatedDate,
+            Location = location,
+            ReporterId = reporterId,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void AddAttachment(string fileName, string filePath, long fileSize, string uploadedBy)
+    {
+        _attachments.Add(new WasteAttachment(Id, fileName, filePath, fileSize, uploadedBy));
+    }
+
+    public void UpdateDisposalStatus(WasteDisposalStatus status)
+    {
+        DisposalStatus = status;
+    }
+}

--- a/src/Harmoni360.Domain/Entities/Waste/WasteType.cs
+++ b/src/Harmoni360.Domain/Entities/Waste/WasteType.cs
@@ -1,0 +1,48 @@
+using Harmoni360.Domain.Common;
+using Harmoni360.Domain.Enums;
+
+namespace Harmoni360.Domain.Entities.Waste;
+
+public class WasteType : BaseEntity, IAuditableEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string Code { get; private set; } = string.Empty;
+    public WasteClassification Classification { get; private set; }
+    public bool IsRecyclable { get; private set; }
+    public bool IsActive { get; private set; }
+
+    public DateTime CreatedAt { get; private set; }
+    public string CreatedBy { get; private set; } = string.Empty;
+    public DateTime? LastModifiedAt { get; private set; }
+    public string? LastModifiedBy { get; private set; }
+
+    protected WasteType() { }
+
+    public static WasteType Create(string name, string code, WasteClassification classification, bool isRecyclable, string createdBy)
+    {
+        return new WasteType
+        {
+            Name = name,
+            Code = code,
+            Classification = classification,
+            IsRecyclable = isRecyclable,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+    }
+
+    public void Update(string name, WasteClassification classification, bool isRecyclable)
+    {
+        Name = name;
+        Classification = classification;
+        IsRecyclable = isRecyclable;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+
+    public void Deactivate()
+    {
+        IsActive = false;
+        LastModifiedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Harmoni360.Domain/Enums/ModuleType.cs
+++ b/src/Harmoni360.Domain/Enums/ModuleType.cs
@@ -81,5 +81,10 @@ public enum ModuleType
     /// Application Settings Module - System configuration, module settings, security settings
     /// (SuperAdmin/Developer only)
     /// </summary>
-    ApplicationSettings = 16
+    ApplicationSettings = 16,
+
+    /// <summary>
+    /// Waste Management Module - Waste reporting, classification, disposal tracking
+    /// </summary>
+    WasteManagement = 17
 }

--- a/src/Harmoni360.Domain/Enums/WasteEnums.cs
+++ b/src/Harmoni360.Domain/Enums/WasteEnums.cs
@@ -1,0 +1,101 @@
+namespace Harmoni360.Domain.Enums;
+
+public enum WasteClassification
+{
+    NonHazardous = 1,
+    HazardousChemical = 2,
+    HazardousBiological = 3,
+    HazardousRadioactive = 4,
+    Recyclable = 5,
+    Organic = 6,
+    Electronic = 7,
+    Construction = 8,
+    Medical = 9,
+    Universal = 10
+}
+
+public enum WasteSource
+{
+    Laboratory = 1,
+    Cafeteria = 2,
+    Office = 3,
+    Maintenance = 4,
+    Construction = 5,
+    Medical = 6,
+    Classroom = 7,
+    Event = 8,
+    Other = 9
+}
+
+public enum UnitOfMeasure
+{
+    Kilogram = 1,
+    Liter = 2,
+    CubicMeter = 3,
+    Ton = 4,
+    Gallon = 5,
+    Pound = 6,
+    Unit = 7,
+    Container = 8
+}
+
+public enum WasteReportStatus
+{
+    Draft = 1,
+    Submitted = 2,
+    UnderReview = 3,
+    Approved = 4,
+    InStorage = 5,
+    AwaitingPickup = 6,
+    InTransit = 7,
+    Disposed = 8,
+    Rejected = 9,
+    Cancelled = 10
+}
+
+public enum DisposalStatus
+{
+    Scheduled = 1,
+    InProgress = 2,
+    Completed = 3,
+    CertificatePending = 4,
+    Certified = 5,
+    Failed = 6
+}
+
+public enum AttachmentType
+{
+    Photo = 1,
+    Manifest = 2,
+    Certificate = 3,
+    Invoice = 4,
+    Permit = 5,
+    Report = 6,
+    Other = 7
+}
+
+public enum CommentType
+{
+    General = 1,
+    StatusUpdate = 2,
+    ComplianceNote = 3,
+    DisposalUpdate = 4,
+    Correction = 5
+}
+
+public enum ProviderStatus
+{
+    Active = 1,
+    Suspended = 2,
+    Expired = 3,
+    UnderReview = 4,
+    Terminated = 5
+}
+
+public enum ComplianceStatus
+{
+    Compliant = 1,
+    NonCompliant = 2,
+    PendingReview = 3,
+    Overdue = 4
+}

--- a/src/Harmoni360.Domain/Interfaces/IWasteReportRepository.cs
+++ b/src/Harmoni360.Domain/Interfaces/IWasteReportRepository.cs
@@ -1,0 +1,8 @@
+using Harmoni360.Domain.Entities.Waste;
+
+namespace Harmoni360.Domain.Interfaces;
+
+public interface IWasteReportRepository : IRepository<WasteReport>
+{
+    Task<WasteReport?> GetByIdWithDetailsAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/src/Harmoni360.Infrastructure/DependencyInjection.cs
+++ b/src/Harmoni360.Infrastructure/DependencyInjection.cs
@@ -35,6 +35,7 @@ public static class DependencyInjection
         // Add repositories
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         services.AddScoped<IIncidentRepository, IncidentRepository>();
+        services.AddScoped<IWasteReportRepository, WasteReportRepository>();
 
         // Add caching
         var redisConnectionString = configuration.GetConnectionString("Redis");
@@ -56,6 +57,7 @@ public static class DependencyInjection
         services.AddHttpContextAccessor();
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddScoped<IFileStorageService, LocalFileStorageService>();
+        services.AddSingleton<IAntivirusScanner, NullAntivirusScanner>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<IPasswordHashService, PasswordHashService>();
         

--- a/src/Harmoni360.Infrastructure/Migrations/20250614000000_AddWasteManagement.cs
+++ b/src/Harmoni360.Infrastructure/Migrations/20250614000000_AddWasteManagement.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Harmoni360.Infrastructure.Migrations
+{
+    public partial class AddWasteManagement : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WasteReports",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    Category = table.Column<int>(type: "integer", nullable: false),
+                    GeneratedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Location = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    DisposalStatus = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    ReporterId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteReports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WasteReports_Users_ReporterId",
+                        column: x => x.ReporterId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WasteAttachments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    WasteReportId = table.Column<int>(type: "integer", nullable: false),
+                    FileName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    FilePath = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    FileSize = table.Column<long>(type: "bigint", nullable: false),
+                    UploadedBy = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    UploadedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteAttachments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WasteAttachments_WasteReports_WasteReportId",
+                        column: x => x.WasteReportId,
+                        principalTable: "WasteReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteAttachments_WasteReportId",
+                table: "WasteAttachments",
+                column: "WasteReportId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteReports_ReporterId",
+                table: "WasteReports",
+                column: "ReporterId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "WasteAttachments");
+            migrationBuilder.DropTable(name: "WasteReports");
+        }
+    }
+}

--- a/src/Harmoni360.Infrastructure/Migrations/20250614000100_UpdateWasteManagementWithAdditionalTables.cs
+++ b/src/Harmoni360.Infrastructure/Migrations/20250614000100_UpdateWasteManagementWithAdditionalTables.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Harmoni360.Infrastructure.Migrations
+{
+    public partial class UpdateWasteManagementWithAdditionalTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WasteTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Code = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Classification = table.Column<int>(type: "integer", nullable: false),
+                    IsRecyclable = table.Column<bool>(type: "boolean", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteTypes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DisposalProviders",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    LicenseNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LicenseExpiryDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DisposalProviders", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WasteDisposalRecords",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    WasteReportId = table.Column<int>(type: "integer", nullable: false),
+                    DisposalProviderId = table.Column<int>(type: "integer", nullable: false),
+                    DisposalDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ActualQuantity = table.Column<decimal>(type: "numeric", nullable: false),
+                    Unit = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteDisposalRecords", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WasteDisposalRecords_WasteReports_WasteReportId",
+                        column: x => x.WasteReportId,
+                        principalTable: "WasteReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WasteDisposalRecords_DisposalProviders_DisposalProviderId",
+                        column: x => x.DisposalProviderId,
+                        principalTable: "DisposalProviders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WasteComments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    WasteReportId = table.Column<int>(type: "integer", nullable: false),
+                    Comment = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    CommentedById = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteComments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WasteComments_WasteReports_WasteReportId",
+                        column: x => x.WasteReportId,
+                        principalTable: "WasteReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WasteComments_Users_CommentedById",
+                        column: x => x.CommentedById,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WasteCompliances",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RegulatoryBody = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    RegulationCode = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    RegulationName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    LastModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WasteCompliances", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteDisposalRecords_WasteReportId",
+                table: "WasteDisposalRecords",
+                column: "WasteReportId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteDisposalRecords_DisposalProviderId",
+                table: "WasteDisposalRecords",
+                column: "DisposalProviderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteComments_WasteReportId",
+                table: "WasteComments",
+                column: "WasteReportId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WasteComments_CommentedById",
+                table: "WasteComments",
+                column: "CommentedById");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "WasteCompliances");
+            migrationBuilder.DropTable(name: "WasteComments");
+            migrationBuilder.DropTable(name: "WasteDisposalRecords");
+            migrationBuilder.DropTable(name: "DisposalProviders");
+            migrationBuilder.DropTable(name: "WasteTypes");
+        }
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -3,6 +3,7 @@ using Harmoni360.Domain.Common;
 using Harmoni360.Domain.Entities;
 using Harmoni360.Domain.Entities.Security;
 using Harmoni360.Domain.Entities.Inspections;
+using Harmoni360.Domain.Entities.Waste;
 using Microsoft.EntityFrameworkCore;
 using System.Reflection;
 
@@ -92,6 +93,15 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<InspectionAttachment> InspectionAttachments => Set<InspectionAttachment>();
     public DbSet<InspectionComment> InspectionComments => Set<InspectionComment>();
     public DbSet<FindingAttachment> FindingAttachments => Set<FindingAttachment>();
+
+    // Waste Management
+    public DbSet<WasteReport> WasteReports => Set<WasteReport>();
+    public DbSet<WasteAttachment> WasteAttachments => Set<WasteAttachment>();
+    public DbSet<WasteType> WasteTypes => Set<WasteType>();
+    public DbSet<DisposalProvider> DisposalProviders => Set<DisposalProvider>();
+    public DbSet<WasteDisposalRecord> WasteDisposalRecords => Set<WasteDisposalRecord>();
+    public DbSet<WasteComment> WasteComments => Set<WasteComment>();
+    public DbSet<WasteCompliance> WasteCompliances => Set<WasteCompliance>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/DisposalProviderConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/DisposalProviderConfiguration.cs
@@ -1,0 +1,26 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class DisposalProviderConfiguration : IEntityTypeConfiguration<DisposalProvider>
+{
+    public void Configure(EntityTypeBuilder<DisposalProvider> builder)
+    {
+        builder.HasKey(d => d.Id);
+
+        builder.Property(d => d.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(d => d.LicenseNumber)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(d => d.Status)
+            .HasConversion<int>();
+
+        builder.ToTable("DisposalProviders");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteAttachmentConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteAttachmentConfiguration.cs
@@ -1,0 +1,30 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteAttachmentConfiguration : IEntityTypeConfiguration<WasteAttachment>
+{
+    public void Configure(EntityTypeBuilder<WasteAttachment> builder)
+    {
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.FileName)
+            .IsRequired()
+            .HasMaxLength(255);
+
+        builder.Property(a => a.FilePath)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(a => a.UploadedBy)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(a => a.FileSize)
+            .IsRequired();
+
+        builder.ToTable("WasteAttachments");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteCommentConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteCommentConfiguration.cs
@@ -1,0 +1,27 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteCommentConfiguration : IEntityTypeConfiguration<WasteComment>
+{
+    public void Configure(EntityTypeBuilder<WasteComment> builder)
+    {
+        builder.HasKey(w => w.Id);
+
+        builder.Property(w => w.Comment)
+            .IsRequired()
+            .HasMaxLength(1000);
+
+        builder.Property(w => w.Type)
+            .HasConversion<int>();
+
+        builder.HasOne(w => w.CommentedBy)
+            .WithMany()
+            .HasForeignKey(w => w.CommentedById)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.ToTable("WasteComments");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteComplianceConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteComplianceConfiguration.cs
@@ -1,0 +1,30 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteComplianceConfiguration : IEntityTypeConfiguration<WasteCompliance>
+{
+    public void Configure(EntityTypeBuilder<WasteCompliance> builder)
+    {
+        builder.HasKey(w => w.Id);
+
+        builder.Property(w => w.RegulatoryBody)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(w => w.RegulationCode)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(w => w.RegulationName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(w => w.Status)
+            .HasConversion<int>();
+
+        builder.ToTable("WasteCompliances");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteDisposalRecordConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteDisposalRecordConfiguration.cs
@@ -1,0 +1,31 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteDisposalRecordConfiguration : IEntityTypeConfiguration<WasteDisposalRecord>
+{
+    public void Configure(EntityTypeBuilder<WasteDisposalRecord> builder)
+    {
+        builder.HasKey(w => w.Id);
+
+        builder.Property(w => w.Unit)
+            .HasConversion<int>();
+
+        builder.Property(w => w.Status)
+            .HasConversion<int>();
+
+        builder.HasOne(w => w.WasteReport)
+            .WithMany()
+            .HasForeignKey(w => w.WasteReportId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(w => w.DisposalProvider)
+            .WithMany()
+            .HasForeignKey(w => w.DisposalProviderId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.ToTable("WasteDisposalRecords");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteReportConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteReportConfiguration.cs
@@ -1,0 +1,43 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteReportConfiguration : IEntityTypeConfiguration<WasteReport>
+{
+    public void Configure(EntityTypeBuilder<WasteReport> builder)
+    {
+        builder.HasKey(w => w.Id);
+
+        builder.Property(w => w.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(w => w.Description)
+            .IsRequired()
+            .HasColumnType("text");
+
+        builder.Property(w => w.Location)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(w => w.Category)
+            .HasConversion<int>();
+
+        builder.Property(w => w.DisposalStatus)
+            .HasConversion<int>();
+
+        builder.HasOne(w => w.Reporter)
+            .WithMany()
+            .HasForeignKey(w => w.ReporterId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(w => w.Attachments)
+            .WithOne()
+            .HasForeignKey(a => a.WasteReportId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.ToTable("WasteReports");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteTypeConfiguration.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Configurations/WasteTypeConfiguration.cs
@@ -1,0 +1,26 @@
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Harmoni360.Infrastructure.Persistence.Configurations;
+
+public class WasteTypeConfiguration : IEntityTypeConfiguration<WasteType>
+{
+    public void Configure(EntityTypeBuilder<WasteType> builder)
+    {
+        builder.HasKey(w => w.Id);
+
+        builder.Property(w => w.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(w => w.Code)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(w => w.Classification)
+            .HasConversion<int>();
+
+        builder.ToTable("WasteTypes");
+    }
+}

--- a/src/Harmoni360.Infrastructure/Persistence/Repositories/WasteReportRepository.cs
+++ b/src/Harmoni360.Infrastructure/Persistence/Repositories/WasteReportRepository.cs
@@ -1,0 +1,20 @@
+using Harmoni360.Domain.Entities.Waste;
+using Harmoni360.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Harmoni360.Infrastructure.Persistence.Repositories;
+
+public class WasteReportRepository : Repository<WasteReport>, IWasteReportRepository
+{
+    public WasteReportRepository(ApplicationDbContext context) : base(context)
+    {
+    }
+
+    public async Task<WasteReport?> GetByIdWithDetailsAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .Include(w => w.Reporter)
+            .Include(w => w.Attachments)
+            .FirstOrDefaultAsync(w => w.Id == id, cancellationToken);
+    }
+}

--- a/src/Harmoni360.Infrastructure/Services/NullAntivirusScanner.cs
+++ b/src/Harmoni360.Infrastructure/Services/NullAntivirusScanner.cs
@@ -1,0 +1,13 @@
+using System.IO;
+using Harmoni360.Application.Common.Interfaces;
+
+namespace Harmoni360.Infrastructure.Services;
+
+public class NullAntivirusScanner : IAntivirusScanner
+{
+    public Task ScanAsync(Stream fileStream, CancellationToken cancellationToken = default)
+    {
+        // No-op scanner used in development environments
+        return Task.CompletedTask;
+    }
+}

--- a/src/Harmoni360.Web/ClientApp/src/features/waste-management/index.ts
+++ b/src/Harmoni360.Web/ClientApp/src/features/waste-management/index.ts
@@ -1,0 +1,1 @@
+export * from './wasteApi';

--- a/src/Harmoni360.Web/ClientApp/src/features/waste-management/wasteApi.ts
+++ b/src/Harmoni360.Web/ClientApp/src/features/waste-management/wasteApi.ts
@@ -1,0 +1,39 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export interface WasteReportDto {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  generatedDate: string;
+  location: string;
+  reporterId?: number;
+  reporterName?: string;
+  attachmentsCount: number;
+}
+
+export const wasteApi = createApi({
+  reducerPath: 'wasteApi',
+  baseQuery: fetchBaseQuery({ baseUrl: '/api/' }),
+  endpoints: (builder) => ({
+    getWasteReports: builder.query<WasteReportDto[], { category?: string; search?: string; page?: number; pageSize?: number }>({
+      query: ({ category, search, page = 1, pageSize = 20 } = {}) => {
+        const params = new URLSearchParams();
+        if (category) params.append('category', category);
+        if (search) params.append('search', search);
+        params.append('page', String(page));
+        params.append('pageSize', String(pageSize));
+        return `WasteReport?${params.toString()}`;
+      },
+    }),
+    createWasteReport: builder.mutation<WasteReportDto, FormData>({
+      query: (body) => ({
+        url: 'WasteReport',
+        method: 'POST',
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useGetWasteReportsQuery, useCreateWasteReportMutation } = wasteApi;

--- a/src/Harmoni360.Web/ClientApp/src/pages/waste-management/WasteReportForm.tsx
+++ b/src/Harmoni360.Web/ClientApp/src/pages/waste-management/WasteReportForm.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { useCreateWasteReportMutation } from '../../features/waste-management/wasteApi';
+
+interface FormValues {
+  title: string;
+  description: string;
+  category: string;
+  generatedDate: string;
+  location: string;
+  attachments: FileList;
+}
+
+const WasteReportForm: React.FC = () => {
+  const { register, handleSubmit } = useForm<FormValues>();
+  const [createWasteReport] = useCreateWasteReportMutation();
+
+  const onSubmit = async (data: FormValues) => {
+    const form = new FormData();
+    form.append('title', data.title);
+    form.append('description', data.description);
+    form.append('category', data.category);
+    form.append('generatedDate', data.generatedDate);
+    form.append('location', data.location);
+    for (const file of Array.from(data.attachments || [])) {
+      form.append('attachments', file);
+    }
+    await createWasteReport(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label>Title</label>
+        <input {...register('title', { required: true })} />
+      </div>
+      <div>
+        <label>Description</label>
+        <textarea {...register('description', { required: true })} />
+      </div>
+      <div>
+        <label>Category</label>
+        <select {...register('category', { required: true })}>
+          <option value="Hazardous">Hazardous</option>
+          <option value="NonHazardous">Non-Hazardous</option>
+          <option value="Recyclable">Recyclable</option>
+        </select>
+      </div>
+      <div>
+        <label>Date</label>
+        <input type="date" {...register('generatedDate', { required: true })} />
+      </div>
+      <div>
+        <label>Location</label>
+        <input {...register('location', { required: true })} />
+      </div>
+      <div>
+        <label>Attachments</label>
+        <input type="file" multiple {...register('attachments')} />
+      </div>
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+export default WasteReportForm;

--- a/src/Harmoni360.Web/ClientApp/src/pages/waste-management/WasteReportList.tsx
+++ b/src/Harmoni360.Web/ClientApp/src/pages/waste-management/WasteReportList.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useGetWasteReportsQuery } from '../../features/waste-management/wasteApi';
+
+const WasteReportList: React.FC = () => {
+  const { data = [], isLoading } = useGetWasteReportsQuery();
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Waste Reports</h2>
+      <ul>
+        {data.map((w) => (
+          <li key={w.id}>{w.title} - {w.category}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default WasteReportList;

--- a/src/Harmoni360.Web/ClientApp/src/pages/waste-management/__tests__/WasteReportList.test.tsx
+++ b/src/Harmoni360.Web/ClientApp/src/pages/waste-management/__tests__/WasteReportList.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import WasteReportList from '../WasteReportList';
+
+test('renders list header', () => {
+  const { getByText } = render(<WasteReportList />);
+  expect(getByText(/Waste Reports/i)).toBeInTheDocument();
+});

--- a/src/Harmoni360.Web/ClientApp/src/pages/waste-management/index.ts
+++ b/src/Harmoni360.Web/ClientApp/src/pages/waste-management/index.ts
@@ -1,0 +1,2 @@
+export { default as WasteReportList } from './WasteReportList';
+export { default as WasteReportForm } from './WasteReportForm';

--- a/src/Harmoni360.Web/ClientApp/src/store/index.ts
+++ b/src/Harmoni360.Web/ClientApp/src/store/index.ts
@@ -10,6 +10,7 @@ import { healthApi } from '../features/health/healthApi';
 import { riskAssessmentApi } from '../features/risk-assessments/riskAssessmentApi';
 import { workPermitApi } from '../features/work-permits/workPermitApi';
 import { securityApi } from '../features/security/securityApi';
+import { wasteApi } from '../features/waste-management/wasteApi';
 import { configurationApi } from '../api/configurationApi';
 import { hazardConfigurationApi } from '../api/hazardConfigurationApi';
 import { applicationModeApi } from '../api/applicationModeApi';
@@ -26,6 +27,7 @@ export const store = configureStore({
     [riskAssessmentApi.reducerPath]: riskAssessmentApi.reducer,
     [workPermitApi.reducerPath]: workPermitApi.reducer,
     [securityApi.reducerPath]: securityApi.reducer,
+    [wasteApi.reducerPath]: wasteApi.reducer,
     [configurationApi.reducerPath]: configurationApi.reducer,
     [hazardConfigurationApi.reducerPath]: hazardConfigurationApi.reducer,
     [applicationModeApi.reducerPath]: applicationModeApi.reducer,
@@ -45,6 +47,7 @@ export const store = configureStore({
       riskAssessmentApi.middleware,
       workPermitApi.middleware,
       securityApi.middleware,
+      wasteApi.middleware,
       configurationApi.middleware,
       hazardConfigurationApi.middleware,
       applicationModeApi.middleware

--- a/src/Harmoni360.Web/Controllers/DisposalProviderController.cs
+++ b/src/Harmoni360.Web/Controllers/DisposalProviderController.cs
@@ -1,0 +1,34 @@
+using Harmoni360.Application.Features.DisposalProviders.Commands;
+using Harmoni360.Application.Features.DisposalProviders.DTOs;
+using Harmoni360.Application.Features.DisposalProviders.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Harmoni360.Web.Controllers;
+
+[ApiController]
+[Route("api/waste/disposal-providers")]
+[Authorize]
+public class DisposalProviderController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    public DisposalProviderController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<DisposalProviderDto>>> GetAll()
+    {
+        var result = await _mediator.Send(new GetDisposalProvidersQuery());
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DisposalProviderDto>> Create(CreateDisposalProviderCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return CreatedAtAction(nameof(GetAll), new { id = result.Id }, result);
+    }
+}

--- a/src/Harmoni360.Web/Controllers/WasteReportController.cs
+++ b/src/Harmoni360.Web/Controllers/WasteReportController.cs
@@ -1,0 +1,48 @@
+using Harmoni360.Application.Features.WasteReports.Commands;
+using Harmoni360.Application.Features.WasteReports.Queries;
+using Harmoni360.Application.Features.WasteReports.DTOs;
+using Harmoni360.Web.Authorization;
+using Harmoni360.Domain.Enums;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Harmoni360.Domain.Entities.Waste;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Harmoni360.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class WasteReportController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public WasteReportController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost]
+    [RequireModulePermission(ModuleType.IncidentManagement, PermissionType.Create)]
+    public async Task<ActionResult<WasteReportDto>> Create([FromForm] CreateWasteReportCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return CreatedAtAction(nameof(GetAll), new { id = result.Id }, result);
+    }
+
+    [HttpGet]
+    [RequireModulePermission(ModuleType.IncidentManagement, PermissionType.Read)]
+    public async Task<ActionResult<List<WasteReportDto>>> GetAll([FromQuery] WasteCategory? category, [FromQuery] string? search, [FromQuery] int page = 1, [FromQuery] int pageSize = 20)
+    {
+        var result = await _mediator.Send(new GetWasteReportsQuery(category, search, page, pageSize));
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/status")]
+    [RequireModulePermission(ModuleType.IncidentManagement, PermissionType.Update)]
+    public async Task<IActionResult> UpdateStatus(int id, [FromBody] WasteDisposalStatus status)
+    {
+        await _mediator.Send(new UpdateDisposalStatusCommand(id, status));
+        return NoContent();
+    }
+}

--- a/tests/Harmoni360.Application.Tests/Harmoni360.Application.Tests.csproj
+++ b/tests/Harmoni360.Application.Tests/Harmoni360.Application.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.18.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Harmoni360.Application\Harmoni360.Application.csproj" />
+    <ProjectReference Include="..\..\src\Harmoni360.Domain\Harmoni360.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Harmoni360.Application.Tests/WasteReportTests.cs
+++ b/tests/Harmoni360.Application.Tests/WasteReportTests.cs
@@ -1,0 +1,16 @@
+using Harmoni360.Domain.Entities.Waste;
+using Xunit;
+
+namespace Harmoni360.Application.Tests;
+
+public class WasteReportTests
+{
+    [Fact]
+    public void Create_SetsMandatoryFields()
+    {
+        var waste = WasteReport.Create("title", "desc", WasteCategory.NonHazardous, DateTime.UtcNow, "loc", null, "tester@demo");
+        Assert.Equal("title", waste.Title);
+        Assert.Equal(WasteCategory.NonHazardous, waste.Category);
+        Assert.Equal("loc", waste.Location);
+    }
+}

--- a/tests/Harmoni360.Web.IntegrationTests/IntegrationTests.csproj
+++ b/tests/Harmoni360.Web.IntegrationTests/IntegrationTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Harmoni360.Web\Harmoni360.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Harmoni360.Web.IntegrationTests/SmokeTests.cs
+++ b/tests/Harmoni360.Web.IntegrationTests/SmokeTests.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace Harmoni360.Web.IntegrationTests;
+
+public class SmokeTests
+{
+    [Fact]
+    public void Placeholder() => Assert.True(true);
+}


### PR DESCRIPTION
## Summary
- expand waste domain with enums and entities
- add provider CRUD scaffolding
- expose disposal provider API endpoints
- create EF migration for additional waste tables

## Testing
- `dotnet test tests/Harmoni360.Application.Tests/Harmoni360.Application.Tests.csproj --no-build`
- `dotnet test tests/Harmoni360.Web.IntegrationTests/IntegrationTests.csproj --no-build`
- `npm test --silent` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_684e1d48229083279aa3463c45985473