### PR TITLE
Fix missing FontAwesome icon in Hazard Dashboard

### DIFF
--- a/src/Harmoni360.Web/ClientApp/src/pages/hazards/HazardDashboard.tsx
+++ b/src/Harmoni360.Web/ClientApp/src/pages/hazards/HazardDashboard.tsx
@@ -22,7 +22,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faPlus,
   faArrowRotateRight,
-  faCog
+  faCog,
+  faExclamationTriangle,
+  faExclamationCircle,
+  faQuestionCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { HubConnectionState } from '@microsoft/signalr';
 
@@ -310,7 +313,7 @@ const HazardDashboard: React.FC = () => {
             value={data.overview?.totalHazards || 0}
             change={data.overview?.totalHazardsChange}
             color="primary"
-            icon="exclamation-triangle"
+            icon={faExclamationTriangle}
           />
         </CCol>
         <CCol sm={6} lg={3}>
@@ -318,7 +321,7 @@ const HazardDashboard: React.FC = () => {
             title="Open Hazards"
             value={data.overview?.openHazards || 0}
             color="warning"
-            icon="exclamation-circle"
+            icon={faExclamationCircle}
           />
         </CCol>
         <CCol sm={6} lg={3}>
@@ -327,7 +330,7 @@ const HazardDashboard: React.FC = () => {
             value={data.overview?.highRiskHazards || 0}
             change={data.overview?.highRiskChange}
             color="danger"
-            icon="exclamation-triangle"
+            icon={faExclamationTriangle}
           />
         </CCol>
         <CCol sm={6} lg={3}>
@@ -335,7 +338,7 @@ const HazardDashboard: React.FC = () => {
             title="Unassessed"
             value={data.overview?.unassessedHazards || 0}
             color="info"
-            icon="question-circle"
+            icon={faQuestionCircle}
           />
         </CCol>
       </CRow>


### PR DESCRIPTION
## Summary
- include `faExclamationTriangle`, `faExclamationCircle`, and `faQuestionCircle`
- use icon objects in HazardDashboard StatsCards

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fccf972a48327999b9746b8b7961c