### PR TITLE
Fix store configuration for inspection and license modules

### DIFF
--- a/src/Harmoni360.Web/ClientApp/src/store/index.ts
+++ b/src/Harmoni360.Web/ClientApp/src/store/index.ts
@@ -10,6 +10,8 @@ import { healthApi } from '../features/health/healthApi';
 import { riskAssessmentApi } from '../features/risk-assessments/riskAssessmentApi';
 import { workPermitApi } from '../features/work-permits/workPermitApi';
 import { auditApi } from '../features/audits/auditApi';
+import { inspectionApi } from '../features/inspections/inspectionApi';
+import { licenseApi } from '../features/licenses/licenseApi';
 import { securityApi } from '../features/security/securityApi';
 import { wasteApi } from '../features/waste-management/wasteApi';
 import { wasteManagementApi } from '../api/wasteManagementApi';
@@ -31,6 +33,8 @@ export const store = configureStore({
     [healthApi.reducerPath]: healthApi.reducer,
     [riskAssessmentApi.reducerPath]: riskAssessmentApi.reducer,
     [workPermitApi.reducerPath]: workPermitApi.reducer,
+    [inspectionApi.reducerPath]: inspectionApi.reducer,
+    [licenseApi.reducerPath]: licenseApi.reducer,
     [auditApi.reducerPath]: auditApi.reducer,
     [securityApi.reducerPath]: securityApi.reducer,
     [wasteApi.reducerPath]: wasteApi.reducer,
@@ -56,6 +60,8 @@ export const store = configureStore({
       healthApi.middleware,
       riskAssessmentApi.middleware,
       workPermitApi.middleware,
+      inspectionApi.middleware,
+      licenseApi.middleware,
       auditApi.middleware,
       securityApi.middleware,
       wasteApi.middleware,

--- a/src/Harmoni360.Web/ClientApp/src/test/utils/test-utils.tsx
+++ b/src/Harmoni360.Web/ClientApp/src/test/utils/test-utils.tsx
@@ -9,6 +9,8 @@ import { healthApi } from '../../features/health/healthApi';
 import { incidentApi } from '../../features/incidents/incidentApi';
 import { ppeApi } from '../../features/ppe/ppeApi';
 import { hazardApi } from '../../features/hazards/hazardApi';
+import { inspectionApi } from '../../features/inspections/inspectionApi';
+import { licenseApi } from '../../features/licenses/licenseApi';
 
 // Create a test store with all the APIs
 const createTestStore = (preloadedState = {}) =>
@@ -20,6 +22,8 @@ const createTestStore = (preloadedState = {}) =>
       [incidentApi.reducerPath]: incidentApi.reducer,
       [ppeApi.reducerPath]: ppeApi.reducer,
       [hazardApi.reducerPath]: hazardApi.reducer,
+      [inspectionApi.reducerPath]: inspectionApi.reducer,
+      [licenseApi.reducerPath]: licenseApi.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
@@ -31,7 +35,9 @@ const createTestStore = (preloadedState = {}) =>
         healthApi.middleware,
         incidentApi.middleware,
         ppeApi.middleware,
-        hazardApi.middleware
+        hazardApi.middleware,
+        inspectionApi.middleware,
+        licenseApi.middleware
       ),
     preloadedState,
   });


### PR DESCRIPTION
## Summary
- include inspectionApi and licenseApi slices in store
- register new API middleware for testing

## Testing
- `npm test -- --coverage --watchAll=false` *(fails: vitest not found)*
- `dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage"` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd4848cd88327b282c6b492790ff5