### PR TITLE
fix: Resolve .NET build errors in main application

### DIFF
--- a/src/Harmoni360.Web/Controllers/AuditController.cs
+++ b/src/Harmoni360.Web/Controllers/AuditController.cs
@@ -205,11 +205,13 @@ namespace Harmoni360.Web.Controllers
         /// </summary>
         [HttpGet("pending")]
         [RequireModulePermission(ModuleType.AuditManagement, PermissionType.Read)]
-        public async Task<IActionResult> GetPendingAudits([FromQuery] GetPendingAuditsQuery query)
+        public async Task<IActionResult> GetPendingAudits([FromQuery] GetAuditsQuery query)
         {
             _logger.LogInformation("Retrieving audits pending action");
             
-            var result = await _mediator.Send(query);
+            // Filter for pending status
+            var pendingQuery = query with { Status = AuditStatus.InProgress };
+            var result = await _mediator.Send(pendingQuery);
             return Ok(result);
         }
 
@@ -218,11 +220,18 @@ namespace Harmoni360.Web.Controllers
         /// </summary>
         [HttpGet("overdue")]
         [RequireModulePermission(ModuleType.AuditManagement, PermissionType.Read)]
-        public async Task<IActionResult> GetOverdueAudits([FromQuery] GetOverdueAuditsQuery query)
+        public async Task<IActionResult> GetOverdueAudits([FromQuery] GetAuditsQuery query)
         {
             _logger.LogInformation("Retrieving overdue audits");
             
-            var result = await _mediator.Send(query);
+            // Filter for overdue audits (InProgress audits with EndDate in the past)
+            var overdueQuery = query with { 
+                Status = AuditStatus.InProgress,
+                EndDate = DateTime.UtcNow,
+                SortBy = "EndDate",
+                SortDescending = false
+            };
+            var result = await _mediator.Send(overdueQuery);
             return Ok(result);
         }
 
@@ -231,7 +240,7 @@ namespace Harmoni360.Web.Controllers
         /// </summary>
         [HttpGet("statistics")]
         [RequireModulePermission(ModuleType.AuditManagement, PermissionType.Read)]
-        public async Task<IActionResult> GetStatistics([FromQuery] GetAuditStatisticsQuery query)
+        public async Task<IActionResult> GetStatistics([FromQuery] GetAuditDashboardQuery query)
         {
             _logger.LogInformation("Retrieving audit statistics");
             

--- a/tests/Harmoni360.Application.Tests/Features/Statistics/ExportHsseStatisticsQueryHandlerTests.cs
+++ b/tests/Harmoni360.Application.Tests/Features/Statistics/ExportHsseStatisticsQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Harmoni360.Application.Features.Statistics.DTOs;
 using Harmoni360.Application.Features.Statistics.Queries;
 using Harmoni360.Application.Tests.Common;
+using Moq;
 using Xunit;
 
 namespace Harmoni360.Application.Tests.Features.Statistics;
@@ -13,7 +14,8 @@ public class ExportHsseStatisticsQueryHandlerTests : BaseTest
     public ExportHsseStatisticsQueryHandlerTests()
     {
         SeedData();
-        var mediator = new MediatR.Mediator(_ => Task.FromResult<object?>(new HsseStatisticsDto()));
+        var serviceProvider = new Mock<IServiceProvider>();
+        var mediator = new MediatR.Mediator(serviceProvider.Object);
         _handler = new ExportHsseStatisticsQueryHandler(mediator);
     }
 

--- a/tests/Harmoni360.Application.Tests/Features/Statistics/GetHsseTrendQueryHandlerTests.cs
+++ b/tests/Harmoni360.Application.Tests/Features/Statistics/GetHsseTrendQueryHandlerTests.cs
@@ -4,6 +4,10 @@ using Harmoni360.Application.Features.Statistics.Queries;
 using Harmoni360.Application.Tests.Common;
 using Harmoni360.Domain.Entities;
 using Harmoni360.Domain.Entities.Security;
+using static Harmoni360.Domain.Entities.Incident;
+using static Harmoni360.Domain.Entities.Hazard;
+using static Harmoni360.Domain.Entities.Security.SecurityIncident;
+using static Harmoni360.Domain.Entities.HealthIncident;
 using Xunit;
 
 namespace Harmoni360.Application.Tests.Features.Statistics;
@@ -28,10 +32,10 @@ public class GetHsseTrendQueryHandlerTests : BaseTest
     [Fact]
     public async Task Handle_WithData_ReturnsCounts()
     {
-        Context.Incidents.Add(Incident.Create("Test", "desc", Domain.Enums.IncidentSeverity.Minor, DateTime.UtcNow, "loc", "Reporter", "reporter@test.com", "Safety"));
-        Context.Hazards.Add(Hazard.Create("Hazard", "desc", null, null, "loc", Domain.Enums.HazardSeverity.Low, 1, "Safety"));
-        Context.SecurityIncidents.Add(SecurityIncident.Create(Domain.Enums.SecurityIncidentType.PhysicalSecurityBreach, Domain.Enums.SecurityIncidentCategory.UnauthorizedAccess, "test", "desc", Domain.Enums.SecuritySeverity.Low, DateTime.UtcNow, "loc", 1, "tester"));
-        Context.HealthIncidents.Add(HealthIncident.Create(1, Domain.Enums.HealthIncidentType.Injury, Domain.Enums.HealthIncidentSeverity.Minor, "sym", "treat", Domain.Enums.TreatmentLocation.SchoolNurse));
+        Context.Incidents.Add(Incident.Create("Test", "desc", IncidentSeverity.Minor, DateTime.UtcNow, "loc", "Reporter", "reporter@test.com", "Safety"));
+        Context.Hazards.Add(Hazard.Create("Hazard", "desc", null, null, "loc", HazardSeverity.Minor, 1, "Safety"));
+        Context.SecurityIncidents.Add(SecurityIncident.Create(SecurityIncidentType.DataBreach, SecurityIncidentCategory.DataBreach, "test", "desc", SecuritySeverity.Low, DateTime.UtcNow, "loc", 1, "tester"));
+        Context.HealthIncidents.Add(HealthIncident.Create(1, HealthIncidentType.Injury, HealthIncidentSeverity.Minor, "sym", "treat", TreatmentLocation.SchoolNurse));
         await Context.SaveChangesAsync();
 
         var result = await _handler.Handle(new GetHsseTrendQuery(), CancellationToken.None);


### PR DESCRIPTION
- Fix ApplicationDbContext constructor call in BaseTest
- Update User entity creation to use factory methods
- Fix Department entity creation to use factory methods
- Fix ICurrentUserService mock setup with correct properties
- Update AuditController to use existing query types
- Fix enum namespace references in statistics tests
- Update TrainingDto property references from TrainingNumber to TrainingCode

The main application (src/) now builds successfully without errors. Test project errors have been partially addressed with plans for full resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)