### PR TITLE
fix: standardize JSON serialization between backend and frontend

### DIFF
--- a/src/Harmoni360.ElsaStudio/JsonContext/ElsaStudioJsonContext.cs
+++ b/src/Harmoni360.ElsaStudio/JsonContext/ElsaStudioJsonContext.cs
@@ -1,8 +1,10 @@
 using System.Text.Json.Serialization;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Api.Client.Resources.Features.Models;
 
 namespace Harmoni360.ElsaStudio.JsonContext;
 
-// Define source-generated JSON context for common Elsa types
+// Define source-generated JSON context for Elsa API types
 // This avoids NullabilityInfoContext_NotSupported errors in WebAssembly
 [JsonSerializable(typeof(object))]
 [JsonSerializable(typeof(string))]
@@ -16,6 +18,9 @@ namespace Harmoni360.ElsaStudio.JsonContext;
 [JsonSerializable(typeof(DateTime))]
 [JsonSerializable(typeof(DateTimeOffset))]
 [JsonSerializable(typeof(Guid))]
+[JsonSerializable(typeof(ListResponse<FeatureDescriptor>))]
+[JsonSerializable(typeof(FeatureDescriptor))]
+[JsonSerializable(typeof(List<FeatureDescriptor>))]
 public partial class ElsaStudioJsonContext : JsonSerializerContext
 {
 }

--- a/src/Harmoni360.Infrastructure/DependencyInjection.cs
+++ b/src/Harmoni360.Infrastructure/DependencyInjection.cs
@@ -17,6 +17,8 @@ using Elsa.EntityFrameworkCore.Extensions;
 using Elsa.EntityFrameworkCore.Modules.Management;
 using Elsa.EntityFrameworkCore.Modules.Runtime;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Harmoni360.Infrastructure;
 
@@ -123,6 +125,14 @@ public static class DependencyInjection
         services.AddScoped<IModuleDiscoveryService, ModuleDiscoveryService>();
 
         services.AddSingleton<IApplicationModeService, ApplicationModeService>();
+
+        // Configure JSON options for consistency between API and Studio
+        services.Configure<JsonSerializerOptions>(options =>
+        {
+            options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+            options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+            options.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+        });
 
         // Configure Elsa Workflows
         services.AddElsa(elsa => elsa

--- a/src/Harmoni360.Web/Program.cs
+++ b/src/Harmoni360.Web/Program.cs
@@ -14,6 +14,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.FileProviders;
 using Serilog;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Harmoni360.Infrastructure.Persistence;
 using Harmoni360.Application.Common.Interfaces;
 using Harmoni360.Infrastructure.Services;
@@ -45,8 +47,14 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .WriteTo.Console()
     .WriteTo.Seq(context.Configuration["Seq:ServerUrl"] ?? "http://localhost:5341"));
 
-// Add services
-builder.Services.AddControllers();
+// Add services with JSON configuration
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    });
 
 // Elsa handles FastEndpoints configuration internally
 


### PR DESCRIPTION
- Configure consistent JSON options across Web API and Elsa Studio
- Add source-generated JSON context for WebAssembly compatibility
- Ensure both backend (Harmoni360.Web) and frontend (Elsa Studio) use identical serialization settings
- Add ReferenceHandler.IgnoreCycles for complex object graphs

This should resolve the NullabilityInfoContext_NotSupported error by ensuring consistent JSON serialization between the API server and WebAssembly client.

🤖 Generated with [Claude Code](https://claude.ai/code)