### PR TITLE
fix: enable NullabilityInfoContext support for WebAssembly

### DIFF
--- a/src/Harmoni360.ElsaStudio/Harmoni360.ElsaStudio.csproj
+++ b/src/Harmoni360.ElsaStudio/Harmoni360.ElsaStudio.csproj
@@ -10,6 +10,8 @@
     <DebugSymbols>false</DebugSymbols>
     <!-- Disable problematic package folder resolution on Linux -->
     <RestoreFallbackFolders></RestoreFallbackFolders>
+    <!-- Enable NullabilityInfoContext support to fix NullabilityInfoContext_NotSupported error in WebAssembly -->
+    <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add NullabilityInfoContextSupport=true to Harmoni360.ElsaStudio.csproj to resolve the NullabilityInfoContext_NotSupported error in Blazor WebAssembly applications.

This enables System.Text.Json to use reflection-based serialization with nullability information in WebAssembly, fixing the error that occurs when Elsa Studio tries to deserialize JSON responses from the API.

This is the recommended solution from Microsoft for this known issue in .NET 8 Blazor WebAssembly applications.

🤖 Generated with [Claude Code](https://claude.ai/code)